### PR TITLE
Fix/de duplicate multiple connect calls

### DIFF
--- a/src/core/connectionHelpers/baseConnectionHelper.js
+++ b/src/core/connectionHelpers/baseConnectionHelper.js
@@ -28,7 +28,7 @@ export default class BaseConnectionHelper {
 
   startConnectionTokenPolling(isFirstCall=false, expiry=CONNECTION_TOKEN_POLLING_INTERVAL_IN_MS) {
     if (!isFirstCall){
-      this.connectionDetailsProvider.fetchConnectionToken()
+      this.connectionDetailsProvider.fetchConnectionToken(true)
         .then(() => {
           const dateExpiry = this.getConnectionTokenExpiry();
           const now = new Date().getTime();
@@ -44,8 +44,7 @@ export default class BaseConnectionHelper {
     }
     this.isStarted = true;
     this.startConnectionTokenPolling(
-      true, 
-      this.getConnectionTokenExpiry()
+      true
     );
   }
 

--- a/src/core/connectionHelpers/connectionDetailsProvider.js
+++ b/src/core/connectionHelpers/connectionDetailsProvider.js
@@ -24,11 +24,19 @@ export default class ConnectionDetailsProvider {
   }
 
   fetchConnectionDetails() {
-    return this._fetchConnectionDetails().then(() => this.connectionDetails);
+    if(!this.connectionDetails) {
+      return this._fetchConnectionDetails().then(() => this.connectionDetails);
+    } else {
+      return Promise.resolve(this.connectionDetails);
+    }
   }
 
-  fetchConnectionToken() {
-    return this._fetchConnectionDetails().then(() => this.connectionToken);
+  fetchConnectionToken(isRefresh=false) {
+    if (isRefresh) {
+      return this._fetchConnectionDetails().then(() => this.connectionDetails);
+    } else {
+      return Promise.resolve(this.connectionDetails);
+    }
   }
 
   _handleCreateParticipantConnectionResponse(connectionDetails) {

--- a/src/core/connectionHelpers/connectionDetailsProvider.js
+++ b/src/core/connectionHelpers/connectionDetailsProvider.js
@@ -9,6 +9,7 @@ export default class ConnectionDetailsProvider {
     this.connectionDetails = null;
     this.connectionToken = null;
     this.connectionTokenExpiry = null;
+    this.connected = false;
   }
 
   getConnectionToken() {
@@ -23,8 +24,8 @@ export default class ConnectionDetailsProvider {
     return this.connectionDetails;
   }
 
-  fetchConnectionDetails() {
-    if(!this.connectionDetails) {
+  fetchConnectionDetails(isRefresh=false) {
+    if(!this.connected || isRefresh) {
       return this._fetchConnectionDetails().then(() => this.connectionDetails);
     } else {
       return Promise.resolve(this.connectionDetails);
@@ -32,8 +33,8 @@ export default class ConnectionDetailsProvider {
   }
 
   fetchConnectionToken(isRefresh=false) {
-    if (isRefresh) {
-      return this._fetchConnectionDetails().then(() => this.connectionDetails);
+    if (!this.connected || isRefresh) {
+      return this._fetchConnectionDetails().then(() => this.connectionToken);
     } else {
       return Promise.resolve(this.connectionDetails);
     }
@@ -46,6 +47,7 @@ export default class ConnectionDetailsProvider {
     };
     this.connectionToken = connectionDetails.ConnectionCredentials.ConnectionToken;
     this.connectionTokenExpiry = connectionDetails.ConnectionCredentials.Expiry;
+    this.connected = true;
   }
 
   _fetchConnectionDetails() {

--- a/src/core/connectionHelpers/connectionDetailsProvider.spec.js
+++ b/src/core/connectionHelpers/connectionDetailsProvider.spec.js
@@ -59,7 +59,7 @@ describe("ConnectionDetailsProvider", () => {
       test("returns valid url on second call", async () => {
         setup();
         await connectionDetailsProvider.fetchConnectionDetails();
-        const connectionDetails = await connectionDetailsProvider.fetchConnectionDetails();
+        const connectionDetails = await connectionDetailsProvider.fetchConnectionDetails(true);
         expect(connectionDetails.url).toEqual("url2");
         expect(connectionDetails.expiry).toEqual("expiry2");
       });
@@ -74,7 +74,7 @@ describe("ConnectionDetailsProvider", () => {
       test("updates internal state on second call", async () => {
         setup();
         await connectionDetailsProvider.fetchConnectionDetails();
-        await connectionDetailsProvider.fetchConnectionDetails();
+        await connectionDetailsProvider.fetchConnectionDetails(true);
         expect(connectionDetailsProvider.connectionDetails.url).toEqual("url2");
         expect(connectionDetailsProvider.connectionDetails.expiry).toEqual("expiry2");
       });
@@ -88,7 +88,7 @@ describe("ConnectionDetailsProvider", () => {
       test("hits API on second call", async () => {
         setup();
         await connectionDetailsProvider.fetchConnectionDetails();
-        await connectionDetailsProvider.fetchConnectionDetails();
+        await connectionDetailsProvider.fetchConnectionDetails(true);
         expect(chatClient.createParticipantConnection).toHaveBeenCalledTimes(2);
         expect(chatClient.createParticipantConnection).toHaveBeenLastCalledWith(participantToken, [ConnectionInfoType.WEBSOCKET, ConnectionInfoType.CONNECTION_CREDENTIALS]);
       });
@@ -103,8 +103,9 @@ describe("ConnectionDetailsProvider", () => {
 
       test("returns valid connection token on second call", async () => {
         setup();
-        await connectionDetailsProvider.fetchConnectionToken();
-        const connectionToken = await connectionDetailsProvider.fetchConnectionToken();
+        await connectionDetailsProvider.fetchConnectionToken(true);
+        const connectionToken = await connectionDetailsProvider.fetchConnectionToken(true);
+        console.log(connectionToken);
         expect(connectionToken).toBe('token2');
       });
 
@@ -117,7 +118,7 @@ describe("ConnectionDetailsProvider", () => {
       test("updates internal state on second call", async () => {
         setup();
         await connectionDetailsProvider.fetchConnectionToken();
-        await connectionDetailsProvider.fetchConnectionToken();
+        await connectionDetailsProvider.fetchConnectionToken(true);
         expect(connectionDetailsProvider.connectionToken).toBe('token2');
       });
 
@@ -130,7 +131,7 @@ describe("ConnectionDetailsProvider", () => {
       test("hits API on second call", async () => {
         setup();
         await connectionDetailsProvider.fetchConnectionToken();
-        await connectionDetailsProvider.fetchConnectionToken();
+        await connectionDetailsProvider.fetchConnectionToken(true);
         expect(chatClient.createParticipantConnection).toHaveBeenCalledTimes(2);
         expect(chatClient.createParticipantConnection).toHaveBeenLastCalledWith(participantToken, [ConnectionInfoType.WEBSOCKET, ConnectionInfoType.CONNECTION_CREDENTIALS]);
       });


### PR DESCRIPTION
*Issue #, if available:*
#31
*Description of changes:*
Fix of the baseConnectionHelper and connectionDetailsProvider and associated test cases to ensure a connected chat session is not overly connected :) looks like a combination of overloading the _fetchConnectionDetails coupled with the polling logic race condition caused the connection to be called multiple times

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

To replicate this issue 

execute session.connect() and observe 2-3 calls to /participant/connection in the trace



