### PR TITLE
Fix types for attachment apis and add ATTACHMENT to allowed values for ChatTranscriptItem Type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "dist/amazon-connect-chat.js",
   "types": "src/index.d.ts",
   "engines": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -197,10 +197,10 @@ declare namespace connect {
      * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_GetAttachment.html
      * @param args The arguments of the operation.
      */
-    downloadAttachment(args: DownloadAttachmentArgs): Promise<ParticipantServiceResponse<DownloadAttachmentResult>>;
+    downloadAttachment(args: DownloadAttachmentArgs): Promise<Blob>;
     downloadAttachment<T>(
       args: WithMetadata<DownloadAttachmentArgs, T>
-    ): Promise<WithMetadata<ParticipantServiceResponse<DownloadAttachmentResult>, T>>;
+    ): Promise<WithMetadata<Blob, T>>;
 
     /**
      * Sends a message as the current session's participant.
@@ -470,7 +470,7 @@ declare namespace connect {
      * Type of the item: message or event.
      * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_Item.html#connectparticipant-Type-Item-Type
      */
-    readonly Type: "MESSAGE" | "EVENT" | "CONNECTION_ACK";
+    readonly Type: "MESSAGE" | "EVENT" | "ATTACHMENT" | "CONNECTION_ACK";
   }
 
   /**
@@ -528,7 +528,7 @@ declare namespace connect {
     attachment: File;
   }
 
-    /**
+  /**
    * An object that is transformed to a request of the Amazon Connect Participant Service `GetAttachment` API.
    * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_GetAttachment.html
    */
@@ -557,19 +557,6 @@ declare namespace connect {
    * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_CompleteAttachmentUpload.html
    */
   interface SendAttachmentResult {
-  }
-
-  /**
-   * Represents the response of the Amazon Connect Participant Service `GetAttachment` API.
-   * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_GetAttachment.html
-   */
-  interface DownloadAttachmentResult {
-    // This is the pre-signed URL that can be used for uploading the file to Amazon S3 when used in response to StartAttachmentUpload.
-    Url: string;
-
-    // The expiration time of the URL in ISO timestamp.
-    // It's specified in ISO 8601 format: yyyy-MM-ddThh:mm:ss.SSSZ. For example, 2019-11-08T02:41:28.172Z.
-    UrlExpiry: string;
   }
 
   // ======


### PR DESCRIPTION
*Description of changes:*
Fixes the return type for downloadAttachment and adds missing "ATTACHMENT" type for ChatTranscriptItem. This unblocks users who are importing ChatJS as a typescript package.

*Testing*
Built locally with amazon-connect-chat-interface. Confirmed basic functionality works including sending and downloading attachments.

Also invoked ChatJS methods directly and confirmed types match.

Sample fulfilled promise of downloadAttachment:
```
await chatsession.downloadAttachment({ attachmentId: "c9a..." })

Blob {metadata: null, size: 4270, type: "image/jpeg"}
```

Sample attachment ChatTranscriptItem from calling getTranscript:
```
AbsoluteTime: "2021-08-11T17:01:42.973Z"
Attachments: [{…}]
Content: null
ContentType: null
DisplayName: "Matt"
Id: "5e1..."
ParticipantId: "0a3..."
ParticipantRole: "CUSTOMER"
Type: "ATTACHMENT"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
