### PR TITLE
Add missing AttachmentItem type in ChatTranscriptItem and bump to 1.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "main": "dist/amazon-connect-chat.js",
   "types": "src/index.d.ts",
   "engines": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -430,6 +430,11 @@ declare namespace connect {
     readonly AbsoluteTime: string;
 
     /**
+     * List of attachment information.
+     */
+    readonly Attachments?: AttachmentItem[];
+
+    /**
      * The content of the message or event.
      * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_Item.html#connectparticipant-Type-Item-Content
      */
@@ -439,7 +444,7 @@ declare namespace connect {
      * The type of content of the item.
      * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_Item.html#connectparticipant-Type-Item-ContentType
      */
-    readonly ContentType: ChatContentType;
+    readonly ContentType?: ChatContentType;
 
     /**
      * The chat display name of the sender.
@@ -471,6 +476,33 @@ declare namespace connect {
      * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_Item.html#connectparticipant-Type-Item-Type
      */
     readonly Type: "MESSAGE" | "EVENT" | "ATTACHMENT" | "CONNECTION_ACK";
+  }
+
+  /**
+   * Information about an attachment.
+   * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_AttachmentItem.html
+   */
+  interface AttachmentItem {
+    /**
+     * A unique identifier for the attachment.
+     */
+    readonly AttachmentId: string;
+
+    /**
+     * A case-sensitive name of the attachment being uploaded.
+     */
+    readonly AttachmentName: string;
+
+    /**
+     * The MIME file type of the attachment.
+     * For a list of supported file types, see: https://docs.aws.amazon.com/connect/latest/adminguide/amazon-connect-service-limits.html#feature-limits
+     */
+    readonly ContentType: string;
+
+    /**
+     * Status of the attachment.
+     */
+    readonly Status: "APPROVED" | "REJECTED" | "IN_PROGRESS";
   }
 
   /**


### PR DESCRIPTION
*Description of changes:*
* Adds missing optional Attachments field in ChatTranscriptItem interface. It is optional because it's not populated for text messages and events. See https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_Item.html#connectparticipant-Type-Item-Attachments
* Adds missing AttachmentItem interface, see https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_AttachmentItem.html
* Updates ContentType to optional in ChatTranscriptItem since it's not specified for attachments
* Bumps version from 1.1.6 to 1.1.7

*Testing:*

Built locally with amazon-connect-chat-interface. Confirmed basic functionality works including sending and downloading attachments.

Obtained sample transcript items to confirm ChatTranscriptItem interface matches:

Text message:
```
{
    "AbsoluteTime": "2021-08-20T01:40:21.339Z",
    "Content": "hello",
    "ContentType": "text/plain",
    "DisplayName": "a1",
    "Id": "5c0...",
    "ParticipantId": "8d3e...",
    "ParticipantRole": "AGENT",
    "Type": "MESSAGE"
}
```

Event:
```
{
    "AbsoluteTime": "2021-08-20T01:40:17.153Z",
    "Content": null,
    "ContentType": "application/vnd.amazonaws.connect.event.participant.joined",
    "DisplayName": "a1",
    "Id": "25d...",
    "ParticipantId": "8d3...",
    "ParticipantRole": "AGENT",
    "Type": "EVENT"
}
```

Attachment:
```
{
    "AbsoluteTime": "2021-08-20T01:40:16.148Z",
    "Attachments": [
        {
            "AttachmentId": "4fd9...",
            "AttachmentName": "apple.jpg",
            "ContentType": "image/jpeg",
            "Status": "APPROVED"
        }
    ],
    "Content": null,
    "ContentType": null,
    "DisplayName": "Matt",
    "Id": "b7c...",
    "ParticipantId": "822...",
    "ParticipantRole": "CUSTOMER",
    "Type": "ATTACHMENT"
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
