### PR TITLE
Add text/markdown to ContentType enum to support markdown messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "dist/amazon-connect-chat.js",
   "types": "src/index.d.ts",
   "engines": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,7 @@ export const CHAT_EVENTS = {
 
 export const CONTENT_TYPE = {
   textPlain: "text/plain",
+  textMarkdown: "text/markdown",
   textCsv: "text/csv",
   applicationDoc: "application/msword",
   applicationPdf: "application/pdf",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -291,7 +291,9 @@ declare namespace connect {
     | "application/vnd.amazonaws.connect.event.transfer.failed"
     | "application/vnd.amazonaws.connect.event.chat.ended";
 
-  type ChatMessageContentType = "text/plain";
+  type ChatMessageContentType =
+      | "text/plain"
+      | "text/markdown";
 
   type ChatContentType = ChatEventContentType | ChatMessageContentType;
 


### PR DESCRIPTION
*Description of changes:*
Add text/markdown to ContentType enum to support markdown messages.
So the customer can send messages using the following method
```
chatSession.sendMessage({
     "message": "*bold message*",
     "contentType": "text/markdown"
})
```
*Testing:*
ran `npm run release`, verified that build succeeded. Copied the build file to chat-interface and tested sending markdown messages from UI examples. Verified the request reached ACPS and failed due to ACPS validation, there was no exception from chatjs validation https://github.com/amazon-connect/amazon-connect-chatjs/blob/master/src/utils.js#L68.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
