### PR TITLE
set example to enable messageReceipts by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ connect.ChatSession.setGlobalConfig({
   //message receipts use sendEvent API for sending Read/Delivered events https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_SendEvent.html
   features: {
     messageReceipts: {
-      shouldSendMessageReceipts: false, // by default messageReceipts is enabled
+      shouldSendMessageReceipts: true, // DEFAULT: true, set to false to disable Read/Delivered receipts
       throttleTime: 5000 //default throttle time - time to wait before sending Read/Delivered receipt.
     }
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Customers may copy/paste configuration provided in README, and disable message receipts unknowingly.

Be clearer about default setting, and set to `true` if they copy/paste

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
