### PR TITLE
Adding 'application/json' to ChatMessageContentType

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -301,7 +301,8 @@ declare namespace connect {
 
   type ChatMessageContentType =
       | "text/plain"
-      | "text/markdown";
+      | "text/markdown"
+      | "application/json";
 
   type ChatContentType = ChatEventContentType | ChatMessageContentType;
 


### PR DESCRIPTION
*Description of changes:*

This PR adds `application/json` to `ChatMessageContentType` in `index.d.ts`

We already support `application/json` message types, but need to add it to `index.d.ts`. See https://github.com/amazon-connect/amazon-connect-chatjs/blob/master/src/constants.js#L73


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
