### PR TITLE
Add webSocketManagerConfig types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -105,6 +105,12 @@ declare namespace connect {
        */
       readonly level?: ChatLogLevel[keyof ChatLogLevel];
     };
+
+    /** The ws manager configuration. */
+    readonly webSocketManagerConfig?: {
+      /** The current network status */
+      isNetworkOnline?(): boolean; 
+    }
   }
 
   interface ChatLogger {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -106,9 +106,17 @@ declare namespace connect {
       readonly level?: ChatLogLevel[keyof ChatLogLevel];
     };
 
-    /** The ws manager configuration. */
+    /**
+     * Optional global configuration for the webSocketManager.
+     */
     readonly webSocketManagerConfig?: {
-      /** The current network status */
+      /**
+       * Custom util function (synchronous) to check `networkIsConnected` status
+       *  - Used in websocket connection heartbeat
+       *  - Store update boolean value in outer scope, and pass into ChatJS (e.g. native mobile network check in React Native application)
+       * 
+       * @default: () => navigator.onLine; // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine
+       */
       isNetworkOnline?(): boolean; 
     }
   }


### PR DESCRIPTION
*Issue #, if available:*

As part of #153 React native support was added, one the requirements to get it to work is to override the default network online check in the global config, but they types for the config params weren't updated.

*Description of changes:*

Update the `ChatGlobalConfig` interface by adding `webSocketManagerConfig`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
