### PR TITLE
clarify TypeScript support note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Note: this will apply the global `connect` variable to your current scope.
 
 #### TypeScript Support
 
-`amazon-connect-chatjs` is compatible with TypeScript. You'll need to use version `3.0.1` or higher:
+`amazon-connect-chatjs` is compatible with TypeScript. You'll need to use version `typescript@^3.0.1` or higher:
 
 ```ts
 import "amazon-connect-streams";


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Clarify for customers to use `typescript@^3.0.0` because `amazon-connect-chatjs@^3.0.0` does not exist

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
