### PR TITLE
suppress unintended logging when CSM is disabled

### DIFF
--- a/src/service/csmService.js
+++ b/src/service/csmService.js
@@ -69,6 +69,10 @@ class CsmService {
             csmConfig.widgetType : this.widgetType;
     }
 
+    _hasCSMFailedToImport() {
+        return typeof csm === 'undefined';
+    }
+
     getDefaultDimensions() {
         return [
             {
@@ -79,6 +83,8 @@ class CsmService {
     }
 
     addMetric(metric) {
+        if (this._hasCSMFailedToImport()) return;
+
         // if csmService is never initialized, store the metrics in an array
         if (!this.csmInitialized) {
             if (this.metricsToBePublished) {
@@ -101,6 +107,8 @@ class CsmService {
     }
 
     addLatencyMetric(method, timeDifference, category, otherDimensions = []) {
+        if (this._hasCSMFailedToImport()) return;
+
         try {
             const latencyMetric = new csm.Metric(
                 method,
@@ -135,6 +143,8 @@ class CsmService {
     }
 
     addCountAndErrorMetric(method, category, error, otherDimensions = []) {
+        if (this._hasCSMFailedToImport()) return;
+
         try {
             const dimensions = [
                 ...this.getDefaultDimensions(),
@@ -170,6 +180,8 @@ class CsmService {
     }
 
     addCountMetric(method, category, otherDimensions = []) {
+        if (this._hasCSMFailedToImport()) return;
+
         try {
             const dimensions = [
                 ...this.getDefaultDimensions(),
@@ -193,6 +205,8 @@ class CsmService {
     }
 
     addAgentCountMetric(metricName, count) {
+        if (this._hasCSMFailedToImport()) return;
+
         try {
             const _self = this;
             if (csm && csm.API.addCount && metricName) {


### PR DESCRIPTION
*Issue #, if available:*
#171 - initially discovered by this customer, but this is reproducible for browser OR React Native

*Description of changes:*

Add backwards compatible changes stop unnecessary console.logs ERRORS due to ClientSideMetric bug.

#### Root Cause

When `disabledCSM: true` is set, `global.csm` is undefined. CSM is disabled, and should not be invoking `csm.Metric`. HOWEVER, it will still attempt to invoke `csm.Metric` anyways (which was triggering try/catch). The try catch block is causing extra console.logs ERRORS, even though we chose to disable CSM.

## Steps to Reproduce

1) Pass in `disableCSM` flag into `ChatSession.create`

```js
connect.ChatSession.create({
  disableCSM: true, // <---- ADD THIS
  options: {
    region: "ca-central-1", // optional, defaults to `region` set in `connect.ChatSession.setGlobalConfig()`
  },
  chatDetails: {
    ContactId,
    ParticipantId,
    ParticipantToken,
  },
  type: "CUSTOMER", // <---- MUST HAVE THIS
});
```

2) Create a chat session, and the error logs will still output anyways:

<img width="2064" alt="csm-react-native-bug" src="https://github.com/amazon-connect/amazon-connect-chatjs/assets/60903378/77fa0eee-3e1c-418c-9001-6d8e77bba25e">

```
INFO  INFO [2023-06-01T16:20:50.737Z] Amazon-Connect-ChatJS-ChatClient: Successfully get transcript {"contactId": "4b8bebbf-6022-4082-b834-7cf70aebdfa4", "participantId": "755f2548-f5d7-48fb-8531-71c922d07915", "region": "ca-central-1", "sessionType": "CUSTOMER"}
ERROR  ERROR [2023-06-01T16:20:50.738Z] ChatJS-csmService: Failed to addLatencyMetric csm:  ReferenceError: Property 'csm' doesn't exist undefined
ERROR  ERROR [2023-06-01T16:20:50.739Z] ChatJS-csmService: Failed to addCountAndErrorMetric csm:  ReferenceError: Property 'csm' doesn't exist undefined
WARN  ADVANCED_LOG [2023-06-01T16:20:51.639Z]AMZ_WEB_SOCKET_MANAGER:  AMZ_WEB_SOCKET_MANAGER::Message received for topic  aws/chat  {"contactId":"4b8bebbf-6022-4082-b834-7cf70aebdfa4","participantId":"755f2548-f5d7-48fb-8531-71c922d07915","sessionType":"CUSTOMER","region":"ca-central-1"}
WARN  ADVANCED_LOG [2023-06-01T16:20:51.642Z]AMZ_WEB_SOCKET_MANAGER:  AMZ_WEB_SOCKET_MANAGER::WebsocketManager invoke callbacks for topic success  aws/chat  {"contactId":"4b8bebbf-6022-4082-b834-7cf70aebdfa4","participantId":"755f2548-f5d7-48fb-8531-71c922d07915","sessionType":"CUSTOMER","region":"ca-central-1"}
ERROR  ERROR [2023-06-01T16:20:51.643Z] ChatJS-csmService: Failed to addCountMetric csm:  ReferenceError: Property 'csm' doesn't exist undefined
```

## Before ❌

https://github.com/amazon-connect/amazon-connect-chatjs/assets/60903378/8aae2a64-5c2d-4a65-9af0-f168751ae5a3

## AFTER ✅

https://github.com/amazon-connect/amazon-connect-chatjs/assets/60903378/3ca7744b-e76a-404e-9873-140bae2e519e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
