### PR TITLE
make connectionToken accessible from connectionDetails value; addresses #154

### DIFF
--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -211,6 +211,7 @@ class ChatController {
             this.logMetaData,
             connectionDetails
         );
+        this.connectionDetails = connectionDetails;
         this.connectionHelper.onEnded(this._handleEndedConnection.bind(this));
         this.connectionHelper.onConnectionLost(this._handleLostConnection.bind(this));
         this.connectionHelper.onConnectionGain(this._handleGainedConnection.bind(this));


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazon-connect/amazon-connect-chatjs/issues/154

"assigned connectionDetails when calling session.connect so getChatDetails() & chatDetails in onConnectionEstablished contain connectionToken"

`connectionDetails` property seemingly never initialised, meaning connectionToken wasn't accessible on a chat session. The `chatDetails` property in `onConnectionEstablished` and also the `getChatDetails()` method referenced a connectionToken in the types but it was never available.

*Description of changes:*
Assigned value to connectionDetails property when calling `session.connect()` so properties within that can be accessed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
