### PR TITLE
ci: remove Node 14 LTS (EOL 30 Apr 2023) from workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [16.x, 18.x, 19.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Ref: https://nodejs.dev/en/about/releases/

*Issue #, if available:*

*Description of changes:*
Remove Node 14 LTS (EOL 30 Apr 2023) from workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
