### PR TITLE
Fixing delivered receipt logic to avoid deadlock promise

### DIFF
--- a/src/core/MessageReceiptsUtil.js
+++ b/src/core/MessageReceiptsUtil.js
@@ -185,9 +185,13 @@ export default class MessageReceiptsUtil {
                         }
                     }
                     self.logger.debug('send Delivered event:', args, 'read event:', this.lastReadArgs);
-                    Promise.all(PromiseArr).then(res => {
-                        self.resolveReadPromises(contentVal.messageId, res[0]);
-                        self.resolveDeliveredPromises(messageId, res[0]);
+                    Promise.allSettled(PromiseArr).then(res => {
+                        self.resolveDeliveredPromises(messageId, res[0].value || res[0].reason, res[0].status === "rejected");
+                        // PromiseArr will have at most two promises (Delivered receipt promise and latest read receipt promise)
+                        // If result length is longer than 1, there must be a read receipt promise.
+                        if (res.length > 1) {
+                            self.resolveReadPromises(contentVal.messageId, res[1].value || res[1].reason, res[1].status === "rejected");
+                        }
                     });
                 }
             } catch(err) {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #130 #131 

*Description of changes:*
See delivered receipt handling logic:
```
if(eventType === CHAT_EVENTS.INCOMING_READ_RECEIPT) { 
         var sendEventPromise = callback.call(ChatClientContext, ...args); 
         self.resolveReadPromises(messageId, sendEventPromise); 
         self.logger.debug('send Read event:', callback, args); 
     } else { 
         //delivered event is the last event fired 
         //fire delivered for latest messageId 
         //fire read for latest messageId 
         var PromiseArr = [callback.call(ChatClientContext, ...args)]; 
         if(this.lastReadArgs) { 
             var contentVal = typeof this.lastReadArgs[2] === "string" ? JSON.parse(this.lastReadArgs[2]) : this.lastReadArgs[2]; 
             var readEventMessageId = contentVal.messageId; 
             // if readPromise has been resolved for readEventMessageId; readPromiseMap should not contain readEventMessageId 
             // if readPromiseMap contains readEventMessageId; read event has not been called! 
             if (self.readPromiseMap.has(readEventMessageId)) { 
                 PromiseArr.push(callback.call(ChatClientContext, ...this.lastReadArgs)); 
             } 
         } 
         self.logger.debug('send Delivered event:', args, 'read event:', this.lastReadArgs); 
         Promise.all(PromiseArr).then(res => { 
             self.resolveReadPromises(contentVal.messageId, res[0]); 
             self.resolveDeliveredPromises(messageId, res[0]); 
         }); 
     } 
```

Delivered receipt logic is a bit flawed since it assumes two things:
- There is always going to be a read receipt promise
    - We call `self.resolveReadPromises(contentVal.messageId, res[0]); ` regardless of whether we enter the `this.lastReadArgs` if statement
    - This results in a TypeError
- Both promises will always pass
    - We wrap both delivered and read promises in `Promise.all` which will fail if one of the promises fail.  In the scenario with two receipts needing to be sent and the delivered receipt is failing, we still want to send the read receipt. However, with this implementation, both will not send.

The proposed fix will run each promise regardless of how the other promise resolves (using `Promise.allSettled`) and will also only call `resolveReadPromises` if there is a read receipt promise (indicated by `res` array size).
```
Promise.allSettled(PromiseArr).then(res => {
                        self.resolveDeliveredPromises(messageId, res[0].value || res[0].reason, res[0].status === "rejected");
                        if (res.length > 1) {
                            self.resolveReadPromises(contentVal.messageId, res[1].value || res[1].reason, res[1].status === "rejected");
                        }
                    });
```
