### PR TITLE
Add checks in chatController before making API calls

### DIFF
--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -381,7 +381,7 @@ class ChatController {
             return;
         }
         if (this._participantDisconnected) {
-            this.logger.error("Cannot disconnectParticipant when participant is already disconnected");
+            this.logger.error("Cannot call disconnectParticipant when participant is already disconnected");
             return;
         }
         const startTime = new Date().getTime();

--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -92,12 +92,7 @@ class ChatController {
     }
 
     sendMessage(args) {
-        if (!this.connectionHelper) {
-            this.logger.error("Cannot call sendMessage before calling connect()");
-            return;
-        }
-        if (this._participantDisconnected) {
-            this.logger.error("Cannot sendMessage when participant is disconnected");
+        if (!this._validateConnectionStatus('sendMessage')) {
             return;
         }
         const startTime = new Date().getTime();
@@ -111,12 +106,7 @@ class ChatController {
     }
 
     sendAttachment(args){
-        if (!this.connectionHelper) {
-            this.logger.error("Cannot call sendAttachment before calling connect()");
-            return;
-        }
-        if (this._participantDisconnected) {
-            this.logger.error("Cannot sendAttachment when participant is disconnected");
+        if (!this._validateConnectionStatus('sendAttachment')) {
             return;
         }
         const startTime = new Date().getTime();
@@ -130,8 +120,7 @@ class ChatController {
     }
 
     downloadAttachment(args){
-        if (!this.connectionHelper) {
-            this.logger.error("Cannot call downloadAttachment before calling connect()");
+        if (!this._validateConnectionStatus('downloadAttachment')) {
             return;
         }
         const startTime = new Date().getTime();
@@ -144,8 +133,7 @@ class ChatController {
     }
 
     sendEvent(args) {
-        if (!this.connectionHelper) {
-            this.logger.error("Cannot call sendEvent before calling connect()");
+        if (!this._validateConnectionStatus('sendEvent')) {
             return;
         }
         const startTime = new Date().getTime();
@@ -185,8 +173,7 @@ class ChatController {
     }
 
     getTranscript(inputArgs) {
-        if (!this.connectionHelper) {
-            this.logger.error("Cannot call getTranscript before calling connect()");
+        if (!this._validateConnectionStatus('getTranscript')) {
             return;
         }
         const startTime = new Date().getTime();
@@ -376,12 +363,7 @@ class ChatController {
     }
 
     disconnectParticipant() {
-        if (!this.connectionHelper) {
-            this.logger.error("Cannot call disconnectParticipant before calling connect()");
-            return;
-        }
-        if (this._participantDisconnected) {
-            this.logger.error("Cannot call disconnectParticipant when participant is already disconnected");
+        if (!this._validateConnectionStatus('disconnectParticipant')) {
             return;
         }
         const startTime = new Date().getTime();
@@ -445,6 +427,18 @@ class ChatController {
             logEntry.sendInternalLogToServer();
 
         return logEntry;
+    }
+
+    _validateConnectionStatus(functionName) {
+        if (!this.connectionHelper) {
+            this.logger.error(`Cannot call ${functionName} before calling connect()`);
+            return false;
+        }
+        if (this._participantDisconnected) {
+            this.logger.error(`Cannot call ${functionName} when participant is disconnected`);
+            return false;
+        }
+        return true;
     }
 }
 

--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -92,6 +92,14 @@ class ChatController {
     }
 
     sendMessage(args) {
+        if (!this.connectionHelper) {
+            this.logger.error("Cannot call sendMessage before calling connect()");
+            return;
+        }
+        if (this._participantDisconnected) {
+            this.logger.error("Cannot sendMessage when participant is disconnected");
+            return;
+        }
         const startTime = new Date().getTime();
         const metadata = args.metadata || null;
         this.argsValidator.validateSendMessage(args);
@@ -103,6 +111,14 @@ class ChatController {
     }
 
     sendAttachment(args){
+        if (!this.connectionHelper) {
+            this.logger.error("Cannot call sendAttachment before calling connect()");
+            return;
+        }
+        if (this._participantDisconnected) {
+            this.logger.error("Cannot sendAttachment when participant is disconnected");
+            return;
+        }
         const startTime = new Date().getTime();
         const metadata = args.metadata || null;
         //TODO: validation
@@ -114,6 +130,10 @@ class ChatController {
     }
 
     downloadAttachment(args){
+        if (!this.connectionHelper) {
+            this.logger.error("Cannot call downloadAttachment before calling connect()");
+            return;
+        }
         const startTime = new Date().getTime();
         const metadata = args.metadata || null;
         const connectionToken = this.connectionHelper.getConnectionToken();
@@ -124,6 +144,10 @@ class ChatController {
     }
 
     sendEvent(args) {
+        if (!this.connectionHelper) {
+            this.logger.error("Cannot call sendEvent before calling connect()");
+            return;
+        }
         const startTime = new Date().getTime();
         const metadata = args.metadata || null;
         this.argsValidator.validateSendEvent(args);
@@ -161,6 +185,10 @@ class ChatController {
     }
 
     getTranscript(inputArgs) {
+        if (!this.connectionHelper) {
+            this.logger.error("Cannot call getTranscript before calling connect()");
+            return;
+        }
         const startTime = new Date().getTime();
         const metadata = inputArgs.metadata || null;
         const args = {
@@ -348,6 +376,14 @@ class ChatController {
     }
 
     disconnectParticipant() {
+        if (!this.connectionHelper) {
+            this.logger.error("Cannot call disconnectParticipant before calling connect()");
+            return;
+        }
+        if (this._participantDisconnected) {
+            this.logger.error("Cannot disconnectParticipant when participant is already disconnected");
+            return;
+        }
         const startTime = new Date().getTime();
         const connectionToken = this.connectionHelper.getConnectionToken();
         return this.chatClient

--- a/src/core/chatController.spec.js
+++ b/src/core/chatController.spec.js
@@ -57,7 +57,7 @@ describe("ChatController", () => {
 
     beforeEach(() => {
         jest.resetAllMocks();
-
+        console.error = jest.fn();
         const messageHandlers = [];
         const onEndedHandlers = [];
         startResponse = Promise.resolve();
@@ -641,4 +641,96 @@ describe("ChatController", () => {
         });
     });
 
+    test("sendMessage should log an error if called before connect()", async () => {
+        const args = {
+            metadata: "metadata",
+            message: "message",
+            contentType: CONTENT_TYPE.textPlain,
+        };
+        const chatController = getChatController(false);
+        await chatController.sendMessage(args);
+        expect(console.error).toBeCalledWith('Cannot call sendMessage before calling connect()');
+    });
+
+    test("sendMessage should log an error if participant is disconnected", async () => {
+        const args = {
+            metadata: "metadata",
+            message: "message",
+            contentType: CONTENT_TYPE.textPlain,
+        };
+        const chatController = getChatController(false);
+        await chatController.connect();
+        await Utils.delay(1);
+        await chatController.disconnectParticipant();
+        await chatController.sendMessage(args);
+        expect(console.error).toBeCalledWith('Cannot sendMessage when participant is disconnected');
+    });
+
+    test("sendAttachment should log an error if called before connect()", async () => {
+        const args = {
+            metadata: "metadata",
+            attachment: {
+                type: "attachment-type",
+            },
+        };
+        const chatController = getChatController(false);
+        await chatController.sendAttachment(args);
+        expect(console.error).toBeCalledWith('Cannot call sendAttachment before calling connect()');
+    });
+
+    test("sendAttachment should log an error if participant is disconnected", async () => {
+        const args = {
+            metadata: "metadata",
+            attachment: {
+                type: "attachment-type",
+            },
+        };
+        const chatController = getChatController(false);
+        await chatController.connect();
+        await Utils.delay(1);
+        await chatController.disconnectParticipant();
+        await chatController.sendAttachment(args);
+        expect(console.error).toBeCalledWith('Cannot sendAttachment when participant is disconnected');
+    });
+
+    test("downloadAttachment should log an error if called before connect()", async () => {
+        const args = {
+            metadata: "metadata",
+            attachmentId: "attachmentId",
+        };
+        const chatController = getChatController(false);
+        await chatController.downloadAttachment(args);
+        expect(console.error).toBeCalledWith('Cannot call downloadAttachment before calling connect()');
+    });
+
+    test("sendEvent should log an error if called before connect()", async () => {
+        const args = {
+            metadata: "metadata",
+            contentType: CONTENT_TYPE.participantJoined
+        };
+        const chatController = getChatController(false);
+        await chatController.sendEvent(args);
+        expect(console.error).toBeCalledWith('Cannot call sendEvent before calling connect()');
+    });
+
+    test("getTranscript should log an error if called before connect()", async () => {
+        const chatController = getChatController(false);
+        await chatController.getTranscript({});
+        expect(console.error).toBeCalledWith('Cannot call getTranscript before calling connect()');
+    });
+
+    test("disconnectParticipant should log an error if called before connect()", async () => {
+        const chatController = getChatController(false);
+        await chatController.disconnectParticipant();
+        expect(console.error).toBeCalledWith('Cannot call disconnectParticipant before calling connect()');
+    });
+
+    test("disconnectParticipant should log an error if participant is disconnected", async () => {
+        const chatController = getChatController(false);
+        await chatController.connect();
+        await Utils.delay(1);
+        await chatController.disconnectParticipant();
+        await chatController.disconnectParticipant();
+        expect(console.error).toBeCalledWith('Cannot call disconnectParticipant when participant is already disconnected');
+    });
 });

--- a/src/core/chatController.spec.js
+++ b/src/core/chatController.spec.js
@@ -663,7 +663,7 @@ describe("ChatController", () => {
         await Utils.delay(1);
         await chatController.disconnectParticipant();
         await chatController.sendMessage(args);
-        expect(console.error).toBeCalledWith('Cannot sendMessage when participant is disconnected');
+        expect(console.error).toBeCalledWith('Cannot call sendMessage when participant is disconnected');
     });
 
     test("sendAttachment should log an error if called before connect()", async () => {
@@ -690,7 +690,7 @@ describe("ChatController", () => {
         await Utils.delay(1);
         await chatController.disconnectParticipant();
         await chatController.sendAttachment(args);
-        expect(console.error).toBeCalledWith('Cannot sendAttachment when participant is disconnected');
+        expect(console.error).toBeCalledWith('Cannot call sendAttachment when participant is disconnected');
     });
 
     test("downloadAttachment should log an error if called before connect()", async () => {
@@ -703,6 +703,19 @@ describe("ChatController", () => {
         expect(console.error).toBeCalledWith('Cannot call downloadAttachment before calling connect()');
     });
 
+    test("downloadAttachment should log an error if participant is disconnected", async () => {
+        const args = {
+            metadata: "metadata",
+            attachmentId: "attachmentId",
+        };
+        const chatController = getChatController(false);
+        await chatController.connect();
+        await Utils.delay(1);
+        await chatController.disconnectParticipant();
+        await chatController.downloadAttachment(args);
+        expect(console.error).toBeCalledWith('Cannot call downloadAttachment when participant is disconnected');
+    });
+
     test("sendEvent should log an error if called before connect()", async () => {
         const args = {
             metadata: "metadata",
@@ -713,10 +726,32 @@ describe("ChatController", () => {
         expect(console.error).toBeCalledWith('Cannot call sendEvent before calling connect()');
     });
 
+    test("sendEvent should log an error if participant is disconnected", async () => {
+        const args = {
+            metadata: "metadata",
+            contentType: CONTENT_TYPE.participantJoined
+        };
+        const chatController = getChatController(false);
+        await chatController.connect();
+        await Utils.delay(1);
+        await chatController.disconnectParticipant();
+        await chatController.sendEvent(args);
+        expect(console.error).toBeCalledWith('Cannot call sendEvent when participant is disconnected');
+    });
+
     test("getTranscript should log an error if called before connect()", async () => {
         const chatController = getChatController(false);
         await chatController.getTranscript({});
         expect(console.error).toBeCalledWith('Cannot call getTranscript before calling connect()');
+    });
+
+    test("getTranscript should log an error if participant is disconnected", async () => {
+        const chatController = getChatController(false);
+        await chatController.connect();
+        await Utils.delay(1);
+        await chatController.disconnectParticipant();
+        await chatController.getTranscript({});
+        expect(console.error).toBeCalledWith('Cannot call getTranscript when participant is disconnected');
     });
 
     test("disconnectParticipant should log an error if called before connect()", async () => {
@@ -731,6 +766,6 @@ describe("ChatController", () => {
         await Utils.delay(1);
         await chatController.disconnectParticipant();
         await chatController.disconnectParticipant();
-        expect(console.error).toBeCalledWith('Cannot call disconnectParticipant when participant is already disconnected');
+        expect(console.error).toBeCalledWith('Cannot call disconnectParticipant when participant is disconnected');
     });
 });


### PR DESCRIPTION
*Issue #, if available:*

Closes #129, #126

*Description of changes:*

This change adds safeguards to multiple ChatController methods to avoid unnecessary API calls. 
- If the participant is disconnected and we attempt to call a method like `sendMessage`, the code will make an API call and get an error status.
    - To avoid this, we exit early if  `_participantDisconnected` is `true` to avoid hitting the API call
- If the chat session has not yet connected, the code will display an ambiguous `getConnectionToken is not a function` error log
    - To avoid this, we check if `connectionHelper` is initialized before calling any methods that use `getConnectionToken`, and if it is not initialized, we log that `connect()` needs to be called before these APIs can work

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
