### PR TITLE
fix: enable message receipts by default; closes #132

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,8 @@ export const CHAT_CONFIGURATIONS = {
 export const PARTICIPANT_TOKEN_HEADER = "x-amzn-connect-participant-token";
 export const AUTH_HEADER = "X-Amz-Bearer";
 
+export const DEFAULT_MESSAGE_RECEIPTS_THROTTLE_MS = 5000;
+
 export const FEATURES = {
     MESSAGE_RECEIPTS_ENABLED: "MESSAGE_RECEIPTS_ENABLED"
 };

--- a/src/core/chatController.spec.js
+++ b/src/core/chatController.spec.js
@@ -42,10 +42,10 @@ describe("ChatController", () => {
     let endResponse;
 
     function getChatController(shouldSendMessageReceipts = true) {
-        GlobalConfig.update({
-            features: shouldSendMessageReceipts ? [FEATURES.MESSAGE_RECEIPTS_ENABLED] : [],
-            throttleTime: 1000
-        });
+        if (!shouldSendMessageReceipts) {
+            GlobalConfig.removeFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
+        }
+        GlobalConfig.updateThrottleTime(1000);
 
         return new ChatController({
             sessionType: SESSION_TYPES.AGENT,

--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -192,11 +192,15 @@ var setGlobalConfig = config => {
     if (csmConfig) {
         csmService.updateCsmConfig(csmConfig);
     }
-    //Message Receipts enabled by default
-    if (!(config.features?.messageReceipts?.shouldSendMessageReceipts === false)) {
-        logger.warn("enabling message-receipts by default; to disable set config.features.messageReceipts.shouldSendMessageReceipts = false");
-        setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
-        GlobalConfig.updateThrottleTime(config.features?.messageReceipts?.throttleTime);
+    /**
+     * Handle setting message receipts feature in Global Config. If no values are given will default to:
+     *   - Message receipts enabled
+     *   - Throttle = 5000 ms
+     */
+    logger.warn("enabling message-receipts by default; to disable set config.features.messageReceipts.shouldSendMessageReceipts = false");
+    GlobalConfig.updateThrottleTime(config.features?.messageReceipts?.throttleTime);
+    if (config.features?.messageReceipts?.shouldSendMessageReceipts === false) {
+        GlobalConfig.removeFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
     }
 };
 

--- a/src/globalConfig.js
+++ b/src/globalConfig.js
@@ -1,3 +1,4 @@
+import { FEATURES, DEFAULT_MESSAGE_RECEIPTS_THROTTLE_MS } from "./constants";
 import { LogManager } from "./log";
 
 class GlobalConfigImpl {
@@ -32,6 +33,8 @@ class GlobalConfigImpl {
                 return true;
             }
         });
+        this.setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED); // message receipts enabled by default
+        this.messageReceiptThrottleTime = DEFAULT_MESSAGE_RECEIPTS_THROTTLE_MS;
         this.featureChangeListeners = [];
     }
     update(configInput) {
@@ -42,7 +45,8 @@ class GlobalConfigImpl {
         this.endpointOverride = config.endpoint || this.endpointOverride;
         this.reconnect = config.reconnect === false ? false : this.reconnect;
         this.messageReceiptThrottleTime = config.throttleTime ? config.throttleTime : 5000;
-        this.features["values"] = Array.isArray(config.features) ? [...config.features] : new Array();
+        const features = config.features || this.features.values;
+        this.features["values"] = Array.isArray(features) ? [...features] : new Array();
     }
 
     updateStageRegionCell(config) {
@@ -58,7 +62,7 @@ class GlobalConfigImpl {
     }
 
     updateThrottleTime(throttleTime) {
-        this.messageReceiptThrottleTime = throttleTime ? throttleTime : this.messageReceiptThrottleTime;
+        this.messageReceiptThrottleTime = throttleTime || this.messageReceiptThrottleTime;
     }
 
     getMessageReceiptsThrottleTime() {
@@ -75,6 +79,14 @@ class GlobalConfigImpl {
 
     getEndpointOverride() {
         return this.endpointOverride;
+    }
+
+    removeFeatureFlag(feature) {
+        if (!this.isFeatureEnabled(feature)) {
+            return;
+        }
+        const index = this.features["values"].indexOf(feature);
+        this.features["values"].splice(index, 1);
     }
 
     setFeatureFlag(feature) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazon-connect/amazon-connect-chatjs/issues/132

*Description of changes:*
Make enable message receipts by default without calling setGlobalConfig()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
