### PR TITLE
fix: ChatSession.getTranscript() fails without arguments; closes #128

### DIFF
--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -172,7 +172,7 @@ class ChatController {
             .catch(this.handleRequestFailure(metadata, ACPS_METHODS.SEND_EVENT, startTime, args.contentType));
     }
 
-    getTranscript(inputArgs) {
+    getTranscript(inputArgs = {}) {
         if (!this._validateConnectionStatus('getTranscript')) {
             return;
         }


### PR DESCRIPTION
*Issue #, if available:*
#128 

*Description of changes:*
FIX: ChatSession.getTranscript() fails without arguments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
