### PR TITLE
expose deep heart beat callbacks to clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.2.3]
+### Fixed
+- .onConnectionEstablished() is fired twice after invoking .connect(); closes #124
+- enable message receipts by default; closes #132
+- expose deep heartbeat success/failure callback to clients
+
+
 ## [2.2.2]
 ### Fixed
 - reject send callbacks instead of returning null

--- a/README.md
+++ b/README.md
@@ -700,6 +700,17 @@ chatSession.onConnectionLost(event => {
 
 Subscribes an event handler that triggers when the session is lost.
 
+##### `chatSession.onDeepHeartbeatFailure()`
+
+```js
+chatSession.onDeepHeartbeatFailure(event => {
+  const { chatDetails, data } = event;
+  // ...
+});
+```
+
+Subscribes an event handler that triggers when deep heartbeat fails.
+
 #### Client side metric
 
 In version `1.2.0` the client side metric(CSM) service is added into this library. Client side metric can provide insights into the real performance and usability, it helps us to understand how customers are actually using the website and what UI experiences they prefer. This feature is enabled by default. User can also disable this feature by passing a flag: `disableCSM` when they create a new chat session:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "dist/amazon-connect-chat.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -48,7 +48,9 @@ export const WEBSOCKET_EVENTS = {
     ConnectionGained: "WebsocketConnectionGained",
     Ended: "WebsocketEnded",
     IncomingMessage: "WebsocketIncomingMessage",
-    InitWebsocket: "InitWebsocket"
+    InitWebsocket: "InitWebsocket",
+    DeepHeartbeatSuccess: "WebsocketDeepHeartbeatSuccess",
+    DeepHeartbeatFailure: "WebsocketDeepHeartbeatFailure"
 };
 
 export const CHAT_EVENTS = {
@@ -64,7 +66,9 @@ export const CHAT_EVENTS = {
     MESSAGE_METADATA: "MESSAGEMETADATA",
     PARTICIPANT_IDLE: "PARTICIPANT_IDLE",
     PARTICIPANT_RETURNED: "PARTICIPANT_RETURNED",
-    AUTODISCONNECTION: "AUTODISCONNECTION"
+    AUTODISCONNECTION: "AUTODISCONNECTION",
+    DEEP_HEARTBEAT_SUCCESS: "DEEP_HEARTBEAT_SUCCESS",
+    DEEP_HEARTBEAT_FAILURE: "DEEP_HEARTBEAT_FAILURE"
 };
 
 export const CONTENT_TYPE = {

--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -245,6 +245,8 @@ class ChatController {
         this.connectionHelper.onConnectionLost(this._handleLostConnection.bind(this));
         this.connectionHelper.onConnectionGain(this._handleGainedConnection.bind(this));
         this.connectionHelper.onMessage(this._handleIncomingMessage.bind(this));
+        this.connectionHelper.onDeepHeartbeatSuccess(this._handleDeepHeartbeatSuccess.bind(this));
+        this.connectionHelper.onDeepHeartbeatFailure(this._handleDeepHeartbeatFailure.bind(this));
         return this.connectionHelper.start();
     }
 
@@ -276,6 +278,20 @@ class ChatController {
         this.hasChatEnded = false;
 
         this._forwardChatEvent(CHAT_EVENTS.CONNECTION_ESTABLISHED, {
+            data: eventData,
+            chatDetails: this.getChatDetails()
+        });
+    }
+
+    _handleDeepHeartbeatSuccess(eventData) {
+        this._forwardChatEvent(CHAT_EVENTS.DEEP_HEARTBEAT_SUCCESS, {
+            data: eventData,
+            chatDetails: this.getChatDetails()
+        });
+    }
+
+    _handleDeepHeartbeatFailure(eventData) {
+        this._forwardChatEvent(CHAT_EVENTS.DEEP_HEARTBEAT_FAILURE, {
             data: eventData,
             chatDetails: this.getChatDetails()
         });
@@ -437,6 +453,10 @@ class ChatController {
             return NetworkLinkStatus.Broken;
         case ConnectionHelperStatus.Connected:
             return NetworkLinkStatus.Established;
+        case ConnectionHelperStatus.DeepHeartbeatSuccess:
+            return NetworkLinkStatus.Established;
+        case ConnectionHelperStatus.DeepHeartbeatFailure:
+            return NetworkLinkStatus.Broken;
         }
         this._sendInternalLogToServer(this.logger.error(
             "Reached invalid state. Unknown connectionHelperStatus: ",

--- a/src/core/chatController.spec.js
+++ b/src/core/chatController.spec.js
@@ -85,6 +85,8 @@ describe("ChatController", () => {
                 onMessage: (handler) => {
                     messageHandlers.push(handler);
                 },
+                onDeepHeartbeatSuccess: () => {},
+                onDeepHeartbeatFailure: () => {},
                 start: () => startResponse,
                 end: () => endResponse,
                 getStatus: () => ConnectionHelperStatus.Connected,
@@ -935,5 +937,33 @@ describe("ChatController", () => {
         } finally {
             expect(console.error).toBeCalledWith('Cannot call disconnectParticipant when participant is disconnected');
         }
+    });
+
+    test('_handleDeepHeartbeatSuccess is triggered correctly', () => {
+        const chatController = getChatController();
+        chatController._forwardChatEvent = jest.fn(); // Mock _forwardChatEvent to spy on it
+
+        // Directly invoke the method
+        chatController._handleDeepHeartbeatSuccess({ message: 'Heartbeat succeeded' });
+
+        // Check if _forwardChatEvent was called correctly
+        expect(chatController._forwardChatEvent).toHaveBeenCalledWith(
+            CHAT_EVENTS.DEEP_HEARTBEAT_SUCCESS,
+            { data: { message: 'Heartbeat succeeded' }, chatDetails: expect.anything() }
+        );
+    });
+
+    test('_handleDeepHeartbeatFailure is triggered correctly', () => {
+        const chatController = getChatController();
+        chatController._forwardChatEvent = jest.fn(); // Mock _forwardChatEvent to spy on it
+
+        // Directly invoke the method
+        chatController._handleDeepHeartbeatFailure({ error: 'Heartbeat failed' });
+
+        // Check if _forwardChatEvent was called correctly
+        expect(chatController._forwardChatEvent).toHaveBeenCalledWith(
+            CHAT_EVENTS.DEEP_HEARTBEAT_FAILURE,
+            { data: { error: 'Heartbeat failed' }, chatDetails: expect.anything() }
+        );
     });
 });

--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -122,6 +122,14 @@ export class ChatSession {
         this.controller.subscribe(CHAT_EVENTS.CONNECTION_LOST, callback);
     }
 
+    onDeepHeartbeatSuccess(callback){
+        this.controller.subscribe(CHAT_EVENTS.DEEP_HEARTBEAT_SUCCESS, callback);
+    }
+
+    onDeepHeartbeatFailure(callback){
+        this.controller.subscribe(CHAT_EVENTS.DEEP_HEARTBEAT_FAILURE, callback);
+    }
+
     sendMessage(args) {
         return this.controller.sendMessage(args);
     }

--- a/src/core/chatSession.spec.js
+++ b/src/core/chatSession.spec.js
@@ -80,6 +80,8 @@ describe("chatSession", () => {
         const cb9 = jest.fn();
         const cb10 = jest.fn();
         const cb11 = jest.fn();
+        const cb12 = jest.fn();
+        const cb13 = jest.fn();
 
         session.onParticipantIdle(cb1);
         session.onParticipantReturned(cb2);
@@ -92,6 +94,8 @@ describe("chatSession", () => {
         session.onConnectionEstablished(cb9);
         session.onEnded(cb10);
         session.onConnectionLost(cb11);
+        session.onDeepHeartbeatSuccess(cb12);
+        session.onDeepHeartbeatFailure(cb13);
 
         controller._forwardChatEvent(CHAT_EVENTS.PARTICIPANT_IDLE, eventData);
         controller._forwardChatEvent(CHAT_EVENTS.PARTICIPANT_RETURNED, eventData);
@@ -104,6 +108,8 @@ describe("chatSession", () => {
         controller._forwardChatEvent(CHAT_EVENTS.CONNECTION_ESTABLISHED, eventData);
         controller._forwardChatEvent(CHAT_EVENTS.CHAT_ENDED, eventData);
         controller._forwardChatEvent(CHAT_EVENTS.CONNECTION_LOST, eventData);
+        controller._forwardChatEvent(CHAT_EVENTS.DEEP_HEARTBEAT_SUCCESS, eventData);
+        controller._forwardChatEvent(CHAT_EVENTS.DEEP_HEARTBEAT_FAILURE, eventData);
 
         await new Promise((r) => setTimeout(r, 0));
 
@@ -118,6 +124,8 @@ describe("chatSession", () => {
         expect(cb9).toHaveBeenCalled();
         expect(cb10).toHaveBeenCalled();
         expect(cb11).toHaveBeenCalled();
+        expect(cb12).toHaveBeenCalled();
+        expect(cb13).toHaveBeenCalled();
     });
 
     test('events', () => {

--- a/src/core/connectionHelpers/LpcConnectionHelper.js
+++ b/src/core/connectionHelpers/LpcConnectionHelper.js
@@ -48,7 +48,9 @@ class LpcConnectionHelper extends BaseConnectionHelper {
             this.baseInstance.onEnded(this.handleEnded.bind(this)),
             this.baseInstance.onConnectionGain(this.handleConnectionGain.bind(this)),
             this.baseInstance.onConnectionLost(this.handleConnectionLost.bind(this)),
-            this.baseInstance.onMessage(this.handleMessage.bind(this))
+            this.baseInstance.onMessage(this.handleMessage.bind(this)),
+            this.baseInstance.onDeepHeartbeatSuccess(this.handleDeepHeartbeatSuccess.bind(this)),
+            this.baseInstance.onDeepHeartbeatFailure(this.handleDeepHeartbeatFailure.bind(this))
         ];
     }
 
@@ -100,6 +102,22 @@ class LpcConnectionHelper extends BaseConnectionHelper {
         this.eventBus.trigger(ConnectionHelperEvents.ConnectionLost, {});
     }
 
+    onDeepHeartbeatSuccess(handler) {
+        return this.eventBus.subscribe(ConnectionHelperEvents.DeepHeartbeatSuccess, handler);
+    }
+
+    handleDeepHeartbeatSuccess() {
+        this.eventBus.trigger(ConnectionHelperEvents.DeepHeartbeatSuccess, {});
+    }
+
+    onDeepHeartbeatFailure(handler) {
+        return this.eventBus.subscribe(ConnectionHelperEvents.DeepHeartbeatFailure, handler);
+    }
+
+    handleDeepHeartbeatFailure() {
+        this.eventBus.trigger(ConnectionHelperEvents.DeepHeartbeatFailure, {});
+    }
+
     onMessage(handler) {
         return this.eventBus.subscribe(ConnectionHelperEvents.IncomingMessage, handler);
     }
@@ -133,7 +151,9 @@ class LpcConnectionHelperBase {
             this.websocketManager.onMessage("aws/chat", this.handleMessage.bind(this)),
             this.websocketManager.onConnectionGain(this.handleConnectionGain.bind(this)),
             this.websocketManager.onConnectionLost(this.handleConnectionLost.bind(this)),
-            this.websocketManager.onInitFailure(this.handleEnded.bind(this))
+            this.websocketManager.onInitFailure(this.handleEnded.bind(this)),
+            this.websocketManager.onDeepHeartbeatSuccess(this.handleDeepHeartbeatSuccess.bind(this)),
+            this.websocketManager.onDeepHeartbeatFailure(this.handleDeepHeartbeatFailure.bind(this))
         ];
         this.logger.info("Initializing websocket manager.");
         if (!websocketManager) {
@@ -270,6 +290,28 @@ class LpcConnectionHelperBase {
             logEntry.sendInternalLogToServer();
 
         return logEntry;
+    }
+
+    onDeepHeartbeatSuccess(handler) {
+        return this.eventBus.subscribe(ConnectionHelperEvents.DeepHeartbeatSuccess, handler);
+    }
+
+    handleDeepHeartbeatSuccess() {
+        this.status = ConnectionHelperStatus.DeepHeartbeatSuccess;
+        this.eventBus.trigger(ConnectionHelperEvents.DeepHeartbeatSuccess, {});
+        csmService.addCountMetric(WEBSOCKET_EVENTS.DeepHeartbeatSuccess, CSM_CATEGORY.API);
+        this.logger.info("Websocket deep heartbeat success.");
+    }
+
+    onDeepHeartbeatFailure(handler) {
+        return this.eventBus.subscribe(ConnectionHelperEvents.DeepHeartbeatFailure, handler);
+    }
+
+    handleDeepHeartbeatFailure() {
+        this.status = ConnectionHelperStatus.DeepHeartbeatFailure;
+        this.eventBus.trigger(ConnectionHelperEvents.DeepHeartbeatFailure, {});
+        csmService.addCountMetric(WEBSOCKET_EVENTS.DeepHeartbeatFailure, CSM_CATEGORY.API);
+        this.logger.info("Websocket deep heartbeat failure.");
     }
 }
 

--- a/src/core/connectionHelpers/baseConnectionHelper.js
+++ b/src/core/connectionHelpers/baseConnectionHelper.js
@@ -5,14 +5,18 @@ const ConnectionHelperStatus = {
     Starting: "Starting",
     Connected: "Connected",
     ConnectionLost: "ConnectionLost",
-    Ended: "Ended"
+    Ended: "Ended",
+    DeepHeartbeatSuccess: "DeepHeartbeatSuccess",
+    DeepHeartbeatFailure: "DeepHeartbeatFailure"
 };
 
 const ConnectionHelperEvents = {
     ConnectionLost: "ConnectionLost", // event data is: {reason: ...}
     ConnectionGained: "ConnectionGained", // event data is: {reason: ...}
     Ended: "Ended", // event data is: {reason: ...}
-    IncomingMessage: "IncomingMessage" // event data is: {payloadString: ...}
+    IncomingMessage: "IncomingMessage", // event data is: {payloadString: ...}
+    DeepHeartbeatSuccess: "DeepHeartbeatSuccess",
+    DeepHeartbeatFailure: "DeepHeartbeatFailure"
 };
 
 const ConnectionInfoType = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Exposing deep heartbeat failure to client
- update CHANGELOG for 2.2.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
