### PR TITLE
add disableCSM typing to ChatJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1]
+### Added
+- add `disableCSM` to custom typings file index.d.ts.
+
 ## [3.0.0]
 ### Added
 - add custom typings file index.d.ts instead of auto-generating typings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-connect-chatjs",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "detect-browser": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/amazon-connect-chat.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -77,6 +77,9 @@ declare namespace connect {
 
   interface CustomerChatSessionArgs extends ChatSessionArgs {
     readonly type: ChatSessionTypes["CUSTOMER"];
+
+    /** disable client-side-metric so errors/debug messages won't be logged with AWS Connect. */
+    readonly disableCSM?: boolean;
   }
 
   interface AgentChatSessionArgs extends ChatSessionArgs {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cx raised an issue where they were not able to access `disableCSM` in new index.d.ts file. Synced up with internal chatJS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
