### PR TITLE
fix message receipts getting disabled if custom throttleTime is passed

### DIFF
--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -217,6 +217,13 @@ var setGlobalConfig = config => {
     GlobalConfig.updateThrottleTime(config.features?.messageReceipts?.throttleTime);
     if (config.features?.messageReceipts?.shouldSendMessageReceipts === false) {
         GlobalConfig.removeFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
+    } else {
+        /**
+         * Note: if update config is called with `config.features` array, it replaces default config
+         * this ensure `message-receipts` feature is always enabled.
+         * Only way to disable message receipts is by setting config.features.messageReceipts.shouldSendMessageReceipts == false
+         * */
+        setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
     }
 };
 

--- a/src/globalConfig.js
+++ b/src/globalConfig.js
@@ -46,7 +46,8 @@ class GlobalConfigImpl {
         this.endpointOverride = config.endpoint || this.endpointOverride;
         this.reconnect = config.reconnect === false ? false : this.reconnect;
         this.messageReceiptThrottleTime = config.throttleTime ? config.throttleTime : 5000;
-        const features = config.features || this.features.values;
+        // update features only if features is of type array.
+        const features = Array.isArray(config.features) ? config.features : this.features.values;
         this.features["values"] = Array.isArray(features) ? [...features] : new Array();
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazon-connect/amazon-connect-chatjs/issues/222

*Description of changes:*
fix message receipts getting disabled if custom throttleTime is passed
- always set message-receipts feature enabled unless explicitly disabled
- features: is of type array only, discard all other updates
- features can be set only by explicitly calling ChatSession.setFeatureFlag API

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
