### PR TITLE
Clean up event subscriptions for agent session when transfer.succeede…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-connect-chatjs",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "detect-browser": "5.3.0",

--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -322,6 +322,11 @@ class ChatController {
                 });
                 this.breakConnection();
             }
+            if (incomingData.ContentType === CONTENT_TYPE.transferSucceeded && this.sessionType !== SESSION_TYPES.CUSTOMER) {
+                // calls LpcConnectionHelper to remove message subscriptions for agent and supervisor sessions in Agent transfer use case
+                // Customer SIM: https://t.corp.amazon.com/P149853425/communication
+                this.breakConnection();
+            }
         } catch (e) {
             this._sendInternalLogToServer(this.logger.error(
                 "Error occured while handling message from Connection. eventData:",


### PR DESCRIPTION
…d is received over websocket

*Issue #, if available:*

* Agent can use Quick Connect to transfer chat to another Agent.
* After transfer, current Agent chat connection - should not receive new messages from websocket 
* this change, cleans up the event listeners and breaks the current chat connection after chat has successfully transferred.

Note: participantId is not provided and transfer.succeeded event is only fanned out to current Agent who initiated the transfer. If 1 or more Agents receive transfer.succeeded event, its expected that all of there chat connections should end.

{\"AbsoluteTime\":\"2024-10-30T21:24:44.572Z\",\"ContentType\":\"application/vnd.amazonaws.connect.event.transfer.succeeded\",\"Id\":\"8ab8...\",\"Type\":\"EVENT\",\"InitialContactId\":\"bf6ae4fa-7eb7...\"}

Before fix

<img width="285" alt="Screenshot 2024-11-24 at 9 44 51 PM" src="https://github.com/user-attachments/assets/83343b7b-ec30-4604-86ca-f66747a34199">


After fix


<img width="546" alt="Screenshot 2024-11-24 at 9 44 33 PM" src="https://github.com/user-attachments/assets/a3950396-7998-47ab-9ddd-cbf518178945">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
