### PR TITLE
Add support for new event `PARTICIPANT_INVITED`

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ const EVENT_CONTENT_TYPE: {
     DELIVERED_RECEIPT: "application/vnd.amazonaws.connect.event.message.delivered",
     PARTICIPANT_JOINED: "application/vnd.amazonaws.connect.event.participant.joined",
     PARTICIPANT_LEFT: "application/vnd.amazonaws.connect.event.participant.left",
+    PARTICIPANT_INVITED: "application/vnd.amazonaws.connect.event.participant.invited",
     TRANSFER_SUCCEEDED: "application/vnd.amazonaws.connect.event.transfer.succeed",
     TRANSFER_FAILED: "application/vnd.amazonaws.connect.event.transfer.failed",
     CONNECTION_ACKNOWLEDGED: "application/vnd.amazonaws.connect.event.connection.acknowledged",
@@ -617,6 +618,29 @@ chatSession.onTyping(event => {
 
 Subscribes an event handler that triggers whenever a `application/vnd.amazonaws.connect.event.typing` event is created by any participant.
 The `data` field has the same schema as `chatSession.onMessage()`.
+
+ ##### `chatSession.onParticipantInvited()`
+  
+ ```js
+ /**
+  * Subscribes an event handler that triggers whenever a "application/vnd.amazonaws.connect.event.participant.invited" event is created by any participant. 
+  * @param {
+     AbsoluteTime?: string,
+     ContentType?: string,
+     Type?: string,
+     ParticipantId?: string,
+     DisplayName?: string,
+     ParticipantRole?: string,
+     InitialContactId?: string
+  } event.data
+  */
+ chatSession.onParticipantInvited(event => {
+   const { chatDetails, data } = event;
+   if (data.ParticipantRole === "AGENT") {
+     // ...
+   }
+ });
+ ```
 
 ##### `chatSession.onParticipantIdle()`
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -66,6 +66,7 @@ export const CHAT_EVENTS = {
     MESSAGE_METADATA: "MESSAGEMETADATA",
     PARTICIPANT_IDLE: "PARTICIPANT_IDLE",
     PARTICIPANT_RETURNED: "PARTICIPANT_RETURNED",
+    PARTICIPANT_INVITED: "PARTICIPANT_INVITED",
     AUTODISCONNECTION: "AUTODISCONNECTION",
     DEEP_HEARTBEAT_SUCCESS: "DEEP_HEARTBEAT_SUCCESS",
     DEEP_HEARTBEAT_FAILURE: "DEEP_HEARTBEAT_FAILURE",
@@ -104,6 +105,7 @@ export const CONTENT_TYPE = {
     deliveredReceipt: "application/vnd.amazonaws.connect.event.message.delivered",
     participantIdle: "application/vnd.amazonaws.connect.event.participant.idle",
     participantReturned: "application/vnd.amazonaws.connect.event.participant.returned",
+    participantInvited: "application/vnd.amazonaws.connect.event.participant.invited",
     autoDisconnection: "application/vnd.amazonaws.connect.event.participant.autodisconnection",
     chatRehydrated: "application/vnd.amazonaws.connect.event.chat.rehydrated"
 };
@@ -114,6 +116,7 @@ export const CHAT_EVENT_TYPE_MAPPING = {
     [CONTENT_TYPE.deliveredReceipt]: CHAT_EVENTS.INCOMING_DELIVERED_RECEIPT,
     [CONTENT_TYPE.participantIdle]: CHAT_EVENTS.PARTICIPANT_IDLE,
     [CONTENT_TYPE.participantReturned]: CHAT_EVENTS.PARTICIPANT_RETURNED,
+    [CONTENT_TYPE.participantInvited]: CHAT_EVENTS.PARTICIPANT_INVITED,
     [CONTENT_TYPE.autoDisconnection]: CHAT_EVENTS.AUTODISCONNECTION,
     [CONTENT_TYPE.chatRehydrated]: CHAT_EVENTS.CHAT_REHYDRATED,
     default: CHAT_EVENTS.INCOMING_MESSAGE,

--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -114,6 +114,10 @@ export class ChatSession {
         this.controller.subscribe(CHAT_EVENTS.PARTICIPANT_RETURNED, callback);
     }
 
+    onParticipantInvited(callback) {
+        this.controller.subscribe(CHAT_EVENTS.PARTICIPANT_INVITED, callback);
+    }
+
     onAutoDisconnection(callback) {
         this.controller.subscribe(CHAT_EVENTS.AUTODISCONNECTION, callback);
     }

--- a/src/core/chatSession.spec.js
+++ b/src/core/chatSession.spec.js
@@ -89,6 +89,7 @@ describe("chatSession", () => {
         const cb12 = jest.fn();
         const cb13 = jest.fn();
         const cb14 = jest.fn();
+        const cb15 = jest.fn();
 
         session.onParticipantIdle(cb1);
         session.onParticipantReturned(cb2);
@@ -104,9 +105,11 @@ describe("chatSession", () => {
         session.onDeepHeartbeatSuccess(cb12);
         session.onDeepHeartbeatFailure(cb13);
         session.onChatRehydrated(cb14);
+        session.onParticipantInvited(cb15);
 
         controller._forwardChatEvent(CHAT_EVENTS.PARTICIPANT_IDLE, eventData);
         controller._forwardChatEvent(CHAT_EVENTS.PARTICIPANT_RETURNED, eventData);
+        controller._forwardChatEvent(CHAT_EVENTS.PARTICIPANT_INVITED, eventData);
         controller._forwardChatEvent(CHAT_EVENTS.AUTODISCONNECTION, eventData);
         controller._forwardChatEvent(CHAT_EVENTS.INCOMING_MESSAGE, eventData);
         controller._forwardChatEvent(CHAT_EVENTS.INCOMING_TYPING, eventData);
@@ -136,6 +139,7 @@ describe("chatSession", () => {
         expect(cb12).toHaveBeenCalled();
         expect(cb13).toHaveBeenCalled();
         expect(cb14).toHaveBeenCalled();
+        expect(cb15).toHaveBeenCalled();
     });
 
     test('events', () => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -304,6 +304,13 @@ declare namespace connect {
      */
     onParticipantReturned(handler: (event: ChatTypingEvent) => void): void;
     
+
+    /**
+     * Subscribes an event handler that triggers whenever a "application/vnd.amazonaws.connect.event.participant.invited" event is received.
+     * @param handler The event handler.
+     */
+    onParticipantInvited(handler: (event: ChatTypingEvent) => void): void;
+
     /**
      * Subscribes an event handler that triggers whenever a "application/vnd.amazonaws.connect.event.participant.autodisconnection" event is created by any participant. 
      * @param handler The event handler.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change will add a handler for new event `PARTICIPANT_INVITED`
Currently, this event is emitted whenever an Agent invites another Agent during an ongoing chat with customer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
