### PR TITLE
Implementing UserAgent configuration for AWSClient + Adding UA suffix property on GlobalConfig

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -22,6 +22,7 @@ import {
 import { LogManager } from "../log";
 import throttle from "lodash.throttle";
 import { CONTENT_TYPE, TYPING_VALIDITY_TIME } from '../constants';
+import packageJson from '../../package.json';
 
 const DEFAULT_PREFIX = "Amazon-Connect-ChatJS-ChatClient";
 
@@ -51,7 +52,8 @@ class ChatClientFactoryImpl {
     return new AWSChatClient({
       endpoint: endpointUrl,
       region: region,
-      logMetaData
+      logMetaData,
+      customUserAgentSuffix: GlobalConfig.getCustomUserAgentSuffix()
     });
   }
 }
@@ -99,6 +101,7 @@ class ChatClient {
 class AWSChatClient extends ChatClient {
   constructor(args) {
     super();
+    const customUserAgent = args.customUserAgentSuffix ? `AmazonConnect-ChatJS/${packageJson.version} ${args.customUserAgentSuffix}` : `AmazonConnect-ChatJS/${packageJson.version}`;
     this.chatClient = new ConnectParticipantClient({
       credentials: {
         accessKeyId: '',
@@ -106,6 +109,7 @@ class AWSChatClient extends ChatClient {
       },
       endpoint: args.endpoint,
       region: args.region,
+      customUserAgent
     });
     this.invokeUrl = args.endpoint;
     this.logger = LogManager.getLogger({ prefix: DEFAULT_PREFIX, logMetaData: args.logMetaData });

--- a/src/globalConfig.js
+++ b/src/globalConfig.js
@@ -37,6 +37,7 @@ class GlobalConfigImpl {
         this.setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED); // message receipts enabled by default
         this.messageReceiptThrottleTime = DEFAULT_MESSAGE_RECEIPTS_THROTTLE_MS;
         this.featureChangeListeners = [];
+        this.customUserAgentSuffix = "";
     }
     update(configInput) {
         var config = configInput || {};
@@ -49,6 +50,7 @@ class GlobalConfigImpl {
         // update features only if features is of type array.
         const features = Array.isArray(config.features) ? config.features : this.features.values;
         this.features["values"] = Array.isArray(features) ? [...features] : new Array();
+        this.customUserAgentSuffix = config.customUserAgentSuffix || this.customUserAgentSuffix;
     }
 
     updateStageRegionCell(config) {
@@ -85,6 +87,10 @@ class GlobalConfigImpl {
 
     getRegionOverride() {
         return this.regionOverride;
+    }
+
+    getCustomUserAgentSuffix() {
+        return this.customUserAgentSuffix;
     }
 
     getEndpointOverride() {

--- a/src/globalConfig.spec.js
+++ b/src/globalConfig.spec.js
@@ -28,7 +28,8 @@ const stageRegionCell2 = {
 const configInput = {
     ...stageRegionCell,
     endpoint: "test-endpoint",
-    regionOverride: "test-regionOverride"
+    regionOverride: "test-regionOverride",
+    customUserAgentSuffix: "test-customUserAgentOverride"
 };
 const logMetaData = {contactId: "abc"};
 const defaultMessageReceiptsError = "WARN [2022-04-12T23:12:36.677Z] ChatJS-GlobalConfig: enabling message-receipts by default; to disable set config.features.messageReceipts.shouldSendMessageReceipts = false ";
@@ -63,6 +64,7 @@ describe("globalConfig", () => {
             expect(GlobalConfig.getCell()).toEqual(configInput.cell);
             expect(GlobalConfig.getEndpointOverride()).toEqual(configInput.endpoint);
             expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(true);
+            expect(GlobalConfig.getCustomUserAgentSuffix()).toEqual(configInput.customUserAgentSuffix);
         });
         it("should update stage, region and cell and fetch correct config", () => {
             GlobalConfig.updateStageRegionCell(stageRegionCell);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR will append a custom suffix on top of the `x-amz-user-agent` custom header.  This PR also adds another property in the GlobalConfig object so consumers of ChatJS can also pass in their custom header.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
