### PR TITLE
Typing & react native doc updates for 3.0.7

### DIFF
--- a/.github/docs/ReactNativeSupport.md
+++ b/.github/docs/ReactNativeSupport.md
@@ -27,7 +27,7 @@ this.session = connect.ChatSession.create({
 
 ## Configuration
 
-Use `amazon-connect-chatjs@^1.5.0` and customize the global configuration:
+Use `"amazon-connect-chatjs@>=1.5.0"` and customize the global configuration:
 
 ```
 connect.ChatSession.setGlobalConfig({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.7]
+### Fixed
+- Updating `ChatGlobalConfig` interface in `index.d.ts` to update `loggerConfig` and `features`, add `region` and `webSocketManagerConfig`
+- Update React Native documentation to specify `amazon-connect-chatjs@>=1.5.0"`
+
 ## [3.0.6]
 ### Added
 - Updating connectivity and websocket logic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "main": "dist/amazon-connect-chat.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -107,17 +107,46 @@ declare namespace connect {
   interface ChatGlobalConfig extends ChatSessionOptions {
     /** The logging configuration. */
     readonly loggerConfig?: {
-      /** The logger object. */
-      readonly logger?: ChatLogger;
+      /** Custom logger implementation */
+      readonly customizedLogger?: {
+        /** Debug level logging function */
+        debug: (...msg: any[]) => void;
+        /** Info level logging function */
+        info: (...msg: any[]) => void;
+        /** Warning level logging function */
+        warn: (...msg: any[]) => void;
+        /** Error level logging function */
+        error: (...msg: any[]) => void;
+      };
 
-      /**
-       * The logging level.
-       * @default connect.ChatSession.LogLevel.INFO
-       */
+      /** The logging level */
       readonly level?: ChatLogLevel[keyof ChatLogLevel];
+      
+      /** Flag to use default logger */
+      readonly useDefaultLogger?: boolean;
     };
-    readonly features?: any;
+
+    /** AWS Region for the chat service */
+    readonly region?: string;
+
+    /** Feature configurations */
+    readonly features?: {
+      /** Message receipt configuration */
+      messageReceipts?: {
+        /** Enable/disable Read/Delivered receipts */
+        shouldSendMessageReceipts?: boolean;
+        /** Throttle time in milliseconds before sending Read/Delivered receipt */
+        throttleTime?: number;
+      };
+    };
+
+    /** Custom user agent suffix */
     readonly customUserAgentSuffix?: string;
+
+    /** WebSocket manager configuration for React Native */
+    readonly webSocketManagerConfig?: {
+      isNetworkOnline: () => boolean;
+    }
   }
 
   interface ChatLogger {


### PR DESCRIPTION
- Updating `ChatGlobalConfig` interface in `index.d.ts` to update `loggerConfig` and `features`, add `region` and `webSocketManagerConfig`

- Update React Native documentation to specify `amazon-connect-chatjs@>=1.5.0"`