### PR TITLE
[NEEDS REBASE] fix(validation): Implement stricter content type validation for sendEvent and sendMessage, address #135

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -200,3 +200,39 @@ export const DUMMY_ENDED_EVENT = {
     Type: "EVENT",
     InitialContactId: ""
 };
+
+// Content types valid for sendMessage operations
+export const SEND_MESSAGE_CONTENT_TYPES = [
+  CONTENT_TYPE.textPlain,
+  CONTENT_TYPE.textMarkdown,
+  CONTENT_TYPE.applicationJson,
+  CONTENT_TYPE.interactiveMessage,
+  CONTENT_TYPE.interactiveMessageResponse
+];
+
+// Content types valid for sendEvent operations
+export const SEND_EVENT_CONTENT_TYPES = [
+  CONTENT_TYPE.typing,
+  CONTENT_TYPE.connectionAcknowledged,
+  CONTENT_TYPE.readReceipt,
+  CONTENT_TYPE.deliveredReceipt,
+  CONTENT_TYPE.participantIdle,
+  CONTENT_TYPE.participantReturned,
+  CONTENT_TYPE.participantInactive,
+  CONTENT_TYPE.participantActive,
+  CONTENT_TYPE.participantJoined,
+  CONTENT_TYPE.participantLeft,
+  CONTENT_TYPE.chatEnded,
+  CONTENT_TYPE.transferSucceeded,
+  CONTENT_TYPE.transferFailed,
+  CONTENT_TYPE.autoDisconnection,
+  CONTENT_TYPE.authenticationInitiated,
+  CONTENT_TYPE.authenticationSuccessful,
+  CONTENT_TYPE.authenticationFailed,
+  CONTENT_TYPE.authenticationTimeout,
+  CONTENT_TYPE.authenticationExpired,
+  CONTENT_TYPE.authenticationCanceled,
+  CONTENT_TYPE.participantDisplayNameUpdated,
+  CONTENT_TYPE.chatRehydrated,
+  CONTENT_TYPE.participantInvited
+];

--- a/src/core/chatArgsValidator.js
+++ b/src/core/chatArgsValidator.js
@@ -1,6 +1,6 @@
 import Utils from "../utils";
 import { IllegalArgumentException } from "./exceptions";
-import { CONTENT_TYPE, SESSION_TYPES } from "../constants";
+import { CONTENT_TYPE, SESSION_TYPES, SEND_MESSAGE_CONTENT_TYPES, SEND_EVENT_CONTENT_TYPES } from "../constants";
 
 class ChatControllerArgsValidator {
     /*eslint-disable no-unused-vars*/
@@ -13,7 +13,15 @@ class ChatControllerArgsValidator {
         if (!Utils.isString(args.message)) {
             throw new IllegalArgumentException(args.message + "is not a valid message");
         }
-        this.validateContentType(args.contentType);
+        this.validateSendMessageContentType(args.contentType);
+    }
+
+    validateSendMessageContentType(contentType) {
+        Utils.assertIsEnum(contentType, SEND_MESSAGE_CONTENT_TYPES, "contentType for sendMessage");
+    }
+
+    validateSendEventContentType(contentType) {
+        Utils.assertIsEnum(contentType, SEND_EVENT_CONTENT_TYPES, "contentType for sendEvent");
     }
 
     validateContentType(contentType) {
@@ -39,7 +47,7 @@ class ChatControllerArgsValidator {
     }
 
     validateSendEvent(args) {
-        this.validateContentType(args.contentType);
+        this.validateSendEventContentType(args.contentType);
     }
 
     /*eslint-disable no-unused-vars*/

--- a/src/core/chatArgsValidator.spec.js
+++ b/src/core/chatArgsValidator.spec.js
@@ -1,3 +1,4 @@
+import { CONTENT_TYPE } from "../constants";
 import { ChatServiceArgsValidator } from "./chatArgsValidator";
 import { IllegalArgumentException } from "./exceptions";
 
@@ -56,5 +57,23 @@ describe("ChatServiceArgsValidator", () => {
         sendEventRequest.contentType = "application/vnd.amazonaws.connect.event.participant.disengaged";
         const validateCall = () => chatArgsValidator.validateSendEvent(sendEventRequest);
         expect(validateCall).toThrow(IllegalArgumentException);
+    });
+
+    test("validateSendMessage only passes on valid content types", () => {
+      const sendMessageRequest = {
+        message: "Hello world",
+        contentType: CONTENT_TYPE.textPlain
+      };
+      const chatArgsValidator = getValidator();
+      chatArgsValidator.validateSendMessage(sendMessageRequest);
+
+      sendMessageRequest.contentType = CONTENT_TYPE.textMarkdown;
+      expect(() => chatArgsValidator.validateSendMessage(sendMessageRequest)).not.toThrow();
+
+      sendMessageRequest.contentType = CONTENT_TYPE.typing;
+      expect(() => chatArgsValidator.validateSendMessage(sendMessageRequest)).toThrow(IllegalArgumentException);
+
+      sendMessageRequest.contentType = "text/html";
+      expect(() => chatArgsValidator.validateSendMessage(sendMessageRequest)).toThrow(IllegalArgumentException);
     });
 });


### PR DESCRIPTION
*Issue #, if available:*

closes #135

*Description of changes:*

fix(validation): Implement stricter content type validation for sendEvent and sendMessage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
