### PR TITLE
publish StreamsJS error metrics when failed to load custom c…

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -200,3 +200,21 @@ export const DUMMY_ENDED_EVENT = {
     Type: "EVENT",
     InitialContactId: ""
 };
+
+export const STREAM_JS = "StreamsJS";
+
+export const CUSTOM_CCP_NAME = "ChatJS";
+
+export const CHAT_SESSION_ERROR_TYPES = {
+    CHATJS_CREATE_SESSION_ERROR: "ChatJSCreateSessionError",
+    CHATJS_CONNECT_SESSION_ERROR: "ChatJSConnectSessionError",
+};
+
+export const STREAM_METRIC_TYPES = {
+    EVENT_METRIC:"EventMetric",
+    SUCCESS_METRIC: "SuccessMetric",
+};
+
+export const STREAM_METRIC_ERROR_TYPES = {
+    INTERNAL_SERVER_ERROR: "InternalServerError",
+};

--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -10,7 +10,10 @@ import {
     ACPS_METHODS,
     FEATURES,
     CREATE_PARTICIPANT_CONACK_FAILURE,
-    CREATE_PARTICIPANT_CONACK_API_CALL_COUNT
+    CREATE_PARTICIPANT_CONACK_API_CALL_COUNT,
+    STREAM_JS,
+    CHAT_SESSION_ERROR_TYPES,
+    STREAM_METRIC_ERROR_TYPES
 } from "../constants";
 import { LogManager } from "../log";
 import { EventBus } from "./eventbus";
@@ -20,6 +23,7 @@ import LpcConnectionHelper from "./connectionHelpers/LpcConnectionHelper";
 import MessageReceiptsUtil from './MessageReceiptsUtil';
 import { csmService } from "../service/csmService";
 import { GlobalConfig } from "../globalConfig";
+import StreamMetricUtils from "../streamMetricUtils";
 
 var NetworkLinkStatus = {
     NeverEstablished: "NeverEstablished",
@@ -387,6 +391,9 @@ class ChatController {
             metadata: this.sessionMetadata
         };
         this._sendInternalLogToServer(this.logger.error("Connect Failed. Error: ", errorObject));
+
+        const metricName = `${STREAM_JS}-${window.connect.version}-${CHAT_SESSION_ERROR_TYPES.CHATJS_CONNECT_SESSION_ERROR}`;
+        StreamMetricUtils.publishError(metricName, STREAM_METRIC_ERROR_TYPES.INTERNAL_SERVER_ERROR);
 
         return Promise.reject(errorObject);
     }

--- a/src/streamMetricUtils.js
+++ b/src/streamMetricUtils.js
@@ -1,0 +1,73 @@
+import { CUSTOM_CCP_NAME, STREAM_METRIC_TYPES } from "./constants";
+import { LogManager } from "./log";
+const logger = LogManager.getLogger({ prefix: "ChatJS-GlobalConfig" });
+
+const StreamMetricUtils = {};
+
+/**
+ * A helper function uses the Steams.js to publish metrics to LDAS - CCPv2 name space
+ * Based on the logic of the publishNativeCustomCCPMetrics function in AmazonConnectCCPUI package,
+ * The metric needs to follow certain patterns to order to be published:
+ * 1) Metric must contain the customCCPName key-value pair.
+ * 2) The value of customCCPName value must be included in SUPPORTED_NATIVE_CUSTOM_CCPS list within the AmazonConnectCCPUI package.
+ * 3) The Metric Type must be one of the three types - SuccessMetric; EventMetric; LatencyMetric.
+ * 4) The Metric name must be in the format of <customCCPName><MetricType>.
+ * 
+ * Example of a valid metric for error:
+ * source: https://code.amazon.com/packages/AmazonConnectCCPUI/blobs/d5aabb168c8f847630c0585c4ed486e2be17e455/--/src/services/CSMService.js#L578
+ * window.connect.publishMetric({
+ *     name: "ChatJSSuccessMetric",  
+ *     data: {
+ *         count: 0
+ *     },
+ *     dimensions: {
+ *         category: "StreamJS-2.18.1-ChatJSCreateSessionError",
+ *         errorType: 'InternalServerError',
+ *         streamsJSVersion: "2.18.1", // based on window.connect.version
+ *         chatJSVersion: "1.0.0", // based on window.connect.ChatJSVersion
+ *     }
+ * })
+ * @param metric Metric to be published
+ */
+StreamMetricUtils.publishMetric = function (metric) {
+    if (!window.connect.publishMetric) return;
+
+    window.connect?.publishMetric (
+        {
+            ...metric,
+            customCCPName: CUSTOM_CCP_NAME,
+        }
+    );
+
+    logger.info("publishMetric - The published Metric is", metric);
+};
+
+/**
+ * Method to publish the StreamJS Error metric
+ * Based on the logic of the publishNativeCustomCCPMetrics function in AmazonConnectCCPUI package,
+ * for error related  metrics, the metric type should be SuccessMetric with the data.count = 0
+ * for now, it only accept the errorType and category dimensions. 
+ * TODO - update the publishNativeCustomCCPMetrics function to allowlist the streamsJSVersion and chatJSVersion dimensions
+ * @param metricName Error Metric name 
+ * @param errorType Error type of the Error Metric
+ */
+StreamMetricUtils.publishError = function (metricName, errorType) {
+    let errorMetric = {
+        name: `${CUSTOM_CCP_NAME}${STREAM_METRIC_TYPES.SUCCESS_METRIC}`,
+        data: {
+            count: 0
+        },
+        dimensions: {
+            category: metricName,
+            errorType: errorType,
+            streamsJSVersion: window.connect.version,
+            chatJSVersion: window.connect.ChatJSVersion,
+        }
+    };
+    StreamMetricUtils.publishMetric(errorMetric);
+
+    logger.info("publishErrorMetric - The Error Metric is", errorMetric);
+
+};
+
+export default StreamMetricUtils;

--- a/src/streamMetricUtils.spec.js
+++ b/src/streamMetricUtils.spec.js
@@ -1,0 +1,140 @@
+import StreamMetricUtils from "./streamMetricUtils";
+import { CUSTOM_CCP_NAME, STREAM_METRIC_TYPES } from "./constants";
+import { LogManager } from "./log";
+
+jest.mock("./log", () => ({
+  LogManager: {
+    getLogger: jest.fn().mockReturnValue({
+      info: jest.fn()
+    })
+  }
+}));
+
+describe("StreamMetricUtils", () => {
+  // Store original window object
+  const originalWindow = global.window;
+  
+  beforeEach(() => {
+    // Setup window object if it doesn't exist
+    if (typeof global.window === 'undefined') {
+      global.window = {};
+    }
+    
+    // Setup connect object
+    global.window.connect = {
+      publishMetric: jest.fn(),
+      version: "2.18.1",
+      ChatJSVersion: "3.0.6"
+    };
+  });
+  
+  afterEach(() => {
+    // Restore original window object
+    global.window = originalWindow;
+    jest.clearAllMocks();
+  });
+  
+  describe(".publishMetric()", () => {
+    it("should call window.connect.publishMetric with the metric and customCCPName", () => {
+      // Arrange
+      const metric = {
+        name: "TestMetric",
+        data: { count: 1 }
+      };
+      
+      // Act
+      StreamMetricUtils.publishMetric(metric);
+      
+      // Assert
+      expect(window.connect.publishMetric).toHaveBeenCalledWith({
+        ...metric,
+        customCCPName: CUSTOM_CCP_NAME
+      });
+    });
+    
+    it("should log the metric being published", () => {
+      // Arrange
+      const metric = {
+        name: "TestMetric",
+        data: { count: 1 }
+      };
+      const logger = LogManager.getLogger();
+      
+      // Act
+      StreamMetricUtils.publishMetric(metric);
+      
+      // Assert
+      expect(logger.info).toHaveBeenCalledWith("publishMetric - The published Metric is", metric);
+    });
+    
+    it("should not throw when publishMetric doesn't exist", () => {
+      // Arrange
+      const metric = {
+        name: "TestMetric",
+        data: { count: 1 }
+      };
+      delete window.connect.publishMetric;
+      
+      // Act & Assert
+      expect(() => StreamMetricUtils.publishMetric(metric)).not.toThrow();
+    });
+  });
+  
+  describe(".publishError()", () => {
+    it("should create an error metric with the correct format", () => {
+      // Arrange
+      const metricName = "StreamJS-2.18.1-ChatJSCreateSessionError";
+      const errorType = "InternalServerError";
+      
+      // Mock the publishMetric function
+      const publishMetricSpy = jest.spyOn(StreamMetricUtils, "publishMetric").mockImplementation(() => {});
+      
+      // Act
+      StreamMetricUtils.publishError(metricName, errorType);
+      
+      // Assert
+      expect(publishMetricSpy).toHaveBeenCalledWith({
+        name: `${CUSTOM_CCP_NAME}${STREAM_METRIC_TYPES.SUCCESS_METRIC}`,
+        data: {
+          count: 0
+        },
+        dimensions: {
+          category: metricName,
+          errorType: errorType,
+          streamsJSVersion: window.connect.version,
+          chatJSVersion: window.connect.ChatJSVersion,
+        }
+      });
+    });
+    
+    it("should log the error metric being published", () => {
+      // Arrange
+      const metricName = "StreamJS-2.18.1-ChatJSCreateSessionError";
+      const errorType = "InternalServerError";
+      const logger = LogManager.getLogger();
+      
+      // Mock the publishMetric function to avoid actual call
+      jest.spyOn(StreamMetricUtils, "publishMetric").mockImplementation(() => {});
+      
+      // Act
+      StreamMetricUtils.publishError(metricName, errorType);
+      
+      // Assert
+      expect(logger.info).toHaveBeenCalledWith(
+        "publishErrorMetric - The Error Metric is", 
+        {
+          name: `${CUSTOM_CCP_NAME}${STREAM_METRIC_TYPES.SUCCESS_METRIC}`,
+          data: {
+            count: 0
+          },
+          dimensions: {
+            category: metricName,
+            errorType: errorType,
+            streamsJSVersion: window.connect.version,
+            chatJSVersion: window.connect.ChatJSVersion,
+          }
+        }
+      );
+    });
+  });
+});


### PR DESCRIPTION
**Descrption of changes:**
Uses StreamJS's [publishMetric](https://github.com/amazon-connect/amazon-connect-streams/blob/5941fd56e4f1fdc8176d397a9c122525f578e0af/src/util.js#L511) function to publish error metrics when Custom CCP Chat session fails to get created or connected.

The same changes are already merged into the internal ChatJS package, and ran manual testing to confirm the error metrics can be generated in the gamma environment. 

* Added Metric Publisher Utils
* Publish error metrics if chatSession.create() or chatSession.connect()fails when loading Custom CCP Chat Session
* Added Unit Tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
