### PR TITLE
Add StreamsJS event metric when createChatController is success

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -210,6 +210,10 @@ export const CHAT_SESSION_ERROR_TYPES = {
     CHATJS_CONNECT_SESSION_ERROR: "ChatJSConnectSessionError",
 };
 
+export const CHAT_SESSION_SUCCESS_TYPES = {
+    CHATJS_CONNECT_SESSION_SUCCESS: "ChatJSConnectSessionSuccess"
+};
+
 export const STREAM_METRIC_TYPES = {
     EVENT_METRIC:"EventMetric",
     SUCCESS_METRIC: "SuccessMetric",

--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -4,7 +4,7 @@ import {
 } from "./exceptions";
 import { ChatClientFactory } from "../client/client";
 import { ChatServiceArgsValidator } from "./chatArgsValidator";
-import { SESSION_TYPES, CHAT_EVENTS, FEATURES, STREAM_JS, CHAT_SESSION_ERROR_TYPES, STREAM_METRIC_ERROR_TYPES } from "../constants";
+import { SESSION_TYPES, CHAT_EVENTS, FEATURES, STREAM_JS, CHAT_SESSION_ERROR_TYPES, STREAM_METRIC_ERROR_TYPES, CHAT_SESSION_SUCCESS_TYPES } from "../constants";
 import { GlobalConfig } from "../globalConfig";
 import { ChatController } from "./chatController";
 import { LogManager, LogLevel, Logger } from "../log";
@@ -70,6 +70,8 @@ class PersistentConnectionAndChatServiceSessionFactory extends ChatSessionFactor
                 websocketManager: websocketManager,
                 logMetaData,
             };
+
+            StreamMetricUtils.publishEvent(`${STREAM_JS}-${window.connect.version}-${CHAT_SESSION_SUCCESS_TYPES.CHATJS_CONNECT_SESSION_SUCCESS}`);
 
             return new ChatController(args);
         }

--- a/src/core/chatSession.spec.js
+++ b/src/core/chatSession.spec.js
@@ -2,12 +2,13 @@ import { ChatSession, ChatSessionObject } from "./chatSession";
 import { csmService } from "../service/csmService";
 import { CHAT_SESSION_FACTORY } from "./chatSession";
 import { ChatController } from "./chatController";
-import { SESSION_TYPES, CHAT_EVENTS, STREAM_JS, CHAT_SESSION_ERROR_TYPES, STREAM_METRIC_ERROR_TYPES } from "../constants";
+import { SESSION_TYPES, CHAT_EVENTS, STREAM_JS, CHAT_SESSION_ERROR_TYPES, STREAM_METRIC_ERROR_TYPES, CHAT_SESSION_SUCCESS_TYPES } from "../constants";
 import { GlobalConfig } from "../globalConfig";
 import StreamMetricUtils from "../streamMetricUtils";
 
 jest.mock('../streamMetricUtils', () => ({
-    publishError: jest.fn()
+    publishError: jest.fn(),
+    publishEvent: jest.fn()
 }));
 
 describe("CSM", () => {
@@ -246,33 +247,36 @@ describe('CHAT_SESSION_FACTORY._createChatController', () => {
         );
     });
 
-    test('should create ChatController successfully when no error occurs', () => {
-        // Arrange
-        const sessionType = 'AGENT';
-        const chatDetails = { contactId: '123', participantId: '456' };
-        const options = {};
-        const websocketManager = {};
-        const normalizedChatDetails = {
-            contactId: '123',
-            participantId: '456',
-            normalized: true
-        };
-
-        // Mock successful normalization
-        jest.spyOn(CHAT_SESSION_FACTORY.argsValidator, 'normalizeChatDetails')
-            .mockReturnValue(normalizedChatDetails);
-
-        // Act
-        const result = CHAT_SESSION_FACTORY._createChatController(
-            sessionType,
-            chatDetails,
-            options,
-            websocketManager
-        );
-
-        // Assert
-        expect(result).toBeDefined();
-        expect(result.constructor.name).toBe('ChatController');
-        expect(StreamMetricUtils.publishError).not.toHaveBeenCalled();
-    });
+    test('should create ChatController successfully when no error occurs', () => {      
+        // Arrange                                                                      
+        const sessionType = 'AGENT';                                                    
+        const chatDetails = { contactId: '123', participantId: '456' };                 
+        const options = {};                                                             
+        const websocketManager = {};                                                    
+        const normalizedChatDetails = {                                                 
+            contactId: '123',                                                           
+            participantId: '456',                                                       
+            normalized: true                                                            
+        };                                                                              
+                                                                                      
+        // Mock successful normalization                                                
+        jest.spyOn(CHAT_SESSION_FACTORY.argsValidator, 'normalizeChatDetails')          
+            .mockReturnValue(normalizedChatDetails);                                    
+                                                                                      
+        // Act                                                                          
+        const result = CHAT_SESSION_FACTORY._createChatController(                      
+            sessionType,                                                                
+            chatDetails,                                                                
+            options,                                                                    
+            websocketManager                                                            
+        );                                                                              
+                                                                                      
+        // Assert                                                                       
+        expect(result).toBeDefined();                                                   
+        expect(result.constructor.name).toBe('ChatController');                         
+        expect(StreamMetricUtils.publishError).not.toHaveBeenCalled();                                                                                                          
+        expect(StreamMetricUtils.publishEvent).toHaveBeenCalledWith(                    
+            expect.stringContaining(CHAT_SESSION_SUCCESS_TYPES.CHATJS_CONNECT_SESSION_SUCCESS)      
+        );                                                                              
+    }); 
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /*eslint no-unused-vars: "off"*/
 import { ChatSessionObject } from "./core/chatSession";
 import { LogManager, LogLevel } from "./log";
-import { getMetadata } from "./metadata";
+import { metadata } from "./metadata";
 
 var global = typeof global !== 'undefined' ? global :
     typeof self !== 'undefined' ? self :
@@ -20,9 +20,4 @@ connect.csmService = connect.csmService || ChatSessionObject.csmService;
 export const ChatSession = ChatSessionObject;
 
 // Expose READ-ONLY global window.connect.ChatJS.version
-Object.defineProperty(global.connect, 'ChatJS', {
-    value: Object.freeze(getMetadata()),
-    writable: false,
-    enumerable: true,
-    configurable: false
-});
+global.connect.ChatJS = metadata;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -33,15 +33,4 @@ describe("Chat JS index file", () => {
         expect(global.connect.ChatJS.version).toBe(process.env.npm_package_version); // "3.x.x"
         expect(global.connect.ChatJS.version).toBe(pkg.version); // "3.x.x"
     });
-
-    test('should not allow modification of ChatJS.version', () => {
-        const originalValue = global.connect.ChatJS.version;
-
-        expect(() => {
-            global.connect.ChatJS.version = 'MODIFIED VERSION';
-        }).toThrow(TypeError);
-
-        expect(global.connect.ChatJS.version).toBe(originalValue);
-        expect(global.connect.ChatJS.version).not.toBe('MODIFIED VERSION');
-    });
 });

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -14,6 +14,3 @@ export const metadata = {
         environment: 'production'
     }
 };
-
-// Expose the metadata with frozen object to prevent tampering
-export const getMetadata = () => Object.freeze({ ...metadata });

--- a/src/streamMetricUtils.js
+++ b/src/streamMetricUtils.js
@@ -70,4 +70,28 @@ StreamMetricUtils.publishError = function (metricName, errorType) {
 
 };
 
+/**
+ * Method to publish the StreamJS Event metric
+ * Based on the logic of the publishNativeCustomCCPMetrics function in AmazonConnectCCPUI package,
+ * for event related metrics, the metric type should be EventMetric with the data.count = 1
+ * @param metricName Event Metric name
+ */
+StreamMetricUtils.publishEvent = function (metricName) {
+    let eventMetric = {
+        name: `${CUSTOM_CCP_NAME}${STREAM_METRIC_TYPES.EVENT_METRIC}`,
+        data: {
+            count: 1
+        },
+        dimensions: {
+            category: metricName,
+            streamsJSVersion: window.connect.version,
+            chatJSVersion: window.connect.ChatJS.version,
+        }
+    };
+    StreamMetricUtils.publishMetric(eventMetric);
+
+    logger.info("publishEventMetric - The Event Metric is", eventMetric);
+
+};
+
 export default StreamMetricUtils;

--- a/src/streamMetricUtils.spec.js
+++ b/src/streamMetricUtils.spec.js
@@ -3,138 +3,138 @@ import { CUSTOM_CCP_NAME, STREAM_METRIC_TYPES } from "./constants";
 import { LogManager } from "./log";
 
 jest.mock("./log", () => ({
-  LogManager: {
-    getLogger: jest.fn().mockReturnValue({
-      info: jest.fn()
-    })
-  }
+    LogManager: {
+        getLogger: jest.fn().mockReturnValue({
+            info: jest.fn()
+        })
+    }
 }));
 
 describe("StreamMetricUtils", () => {
-  // Store original window object
-  const originalWindow = global.window;
+    // Store original window object
+    const originalWindow = global.window;
   
-  beforeEach(() => {
+    beforeEach(() => {
     // Setup window object if it doesn't exist
-    if (typeof global.window === 'undefined') {
-      global.window = {};
-    }
+        if (typeof global.window === 'undefined') {
+            global.window = {};
+        }
     
-    // Setup connect object
-    global.window.connect = {
-      publishMetric: jest.fn(),
-      version: "2.18.1",
-      ChatJSVersion: "3.0.6"
-    };
-  });
+        // Setup connect object
+        global.window.connect = {
+            publishMetric: jest.fn(),
+            version: "2.18.1",
+            ChatJSVersion: "3.0.6"
+        };
+    });
   
-  afterEach(() => {
+    afterEach(() => {
     // Restore original window object
-    global.window = originalWindow;
-    jest.clearAllMocks();
-  });
+        global.window = originalWindow;
+        jest.clearAllMocks();
+    });
   
-  describe(".publishMetric()", () => {
-    it("should call window.connect.publishMetric with the metric and customCCPName", () => {
-      // Arrange
-      const metric = {
-        name: "TestMetric",
-        data: { count: 1 }
-      };
+    describe(".publishMetric()", () => {
+        it("should call window.connect.publishMetric with the metric and customCCPName", () => {
+            // Arrange
+            const metric = {
+                name: "TestMetric",
+                data: { count: 1 }
+            };
       
-      // Act
-      StreamMetricUtils.publishMetric(metric);
+            // Act
+            StreamMetricUtils.publishMetric(metric);
       
-      // Assert
-      expect(window.connect.publishMetric).toHaveBeenCalledWith({
-        ...metric,
-        customCCPName: CUSTOM_CCP_NAME
-      });
-    });
+            // Assert
+            expect(window.connect.publishMetric).toHaveBeenCalledWith({
+                ...metric,
+                customCCPName: CUSTOM_CCP_NAME
+            });
+        });
     
-    it("should log the metric being published", () => {
-      // Arrange
-      const metric = {
-        name: "TestMetric",
-        data: { count: 1 }
-      };
-      const logger = LogManager.getLogger();
+        it("should log the metric being published", () => {
+            // Arrange
+            const metric = {
+                name: "TestMetric",
+                data: { count: 1 }
+            };
+            const logger = LogManager.getLogger();
       
-      // Act
-      StreamMetricUtils.publishMetric(metric);
+            // Act
+            StreamMetricUtils.publishMetric(metric);
       
-      // Assert
-      expect(logger.info).toHaveBeenCalledWith("publishMetric - The published Metric is", metric);
-    });
+            // Assert
+            expect(logger.info).toHaveBeenCalledWith("publishMetric - The published Metric is", metric);
+        });
     
-    it("should not throw when publishMetric doesn't exist", () => {
-      // Arrange
-      const metric = {
-        name: "TestMetric",
-        data: { count: 1 }
-      };
-      delete window.connect.publishMetric;
+        it("should not throw when publishMetric doesn't exist", () => {
+            // Arrange
+            const metric = {
+                name: "TestMetric",
+                data: { count: 1 }
+            };
+            delete window.connect.publishMetric;
       
-      // Act & Assert
-      expect(() => StreamMetricUtils.publishMetric(metric)).not.toThrow();
+            // Act & Assert
+            expect(() => StreamMetricUtils.publishMetric(metric)).not.toThrow();
+        });
     });
-  });
   
-  describe(".publishError()", () => {
-    it("should create an error metric with the correct format", () => {
-      // Arrange
-      const metricName = "StreamJS-2.18.1-ChatJSCreateSessionError";
-      const errorType = "InternalServerError";
+    describe(".publishError()", () => {
+        it("should create an error metric with the correct format", () => {
+            // Arrange
+            const metricName = "StreamJS-2.18.1-ChatJSCreateSessionError";
+            const errorType = "InternalServerError";
       
-      // Mock the publishMetric function
-      const publishMetricSpy = jest.spyOn(StreamMetricUtils, "publishMetric").mockImplementation(() => {});
+            // Mock the publishMetric function
+            const publishMetricSpy = jest.spyOn(StreamMetricUtils, "publishMetric").mockImplementation(() => {});
       
-      // Act
-      StreamMetricUtils.publishError(metricName, errorType);
+            // Act
+            StreamMetricUtils.publishError(metricName, errorType);
       
-      // Assert
-      expect(publishMetricSpy).toHaveBeenCalledWith({
-        name: `${CUSTOM_CCP_NAME}${STREAM_METRIC_TYPES.SUCCESS_METRIC}`,
-        data: {
-          count: 0
-        },
-        dimensions: {
-          category: metricName,
-          errorType: errorType,
-          streamsJSVersion: window.connect.version,
-          chatJSVersion: window.connect.ChatJSVersion,
-        }
-      });
-    });
+            // Assert
+            expect(publishMetricSpy).toHaveBeenCalledWith({
+                name: `${CUSTOM_CCP_NAME}${STREAM_METRIC_TYPES.SUCCESS_METRIC}`,
+                data: {
+                    count: 0
+                },
+                dimensions: {
+                    category: metricName,
+                    errorType: errorType,
+                    streamsJSVersion: window.connect.version,
+                    chatJSVersion: window.connect.ChatJSVersion,
+                }
+            });
+        });
     
-    it("should log the error metric being published", () => {
-      // Arrange
-      const metricName = "StreamJS-2.18.1-ChatJSCreateSessionError";
-      const errorType = "InternalServerError";
-      const logger = LogManager.getLogger();
+        it("should log the error metric being published", () => {
+            // Arrange
+            const metricName = "StreamJS-2.18.1-ChatJSCreateSessionError";
+            const errorType = "InternalServerError";
+            const logger = LogManager.getLogger();
       
-      // Mock the publishMetric function to avoid actual call
-      jest.spyOn(StreamMetricUtils, "publishMetric").mockImplementation(() => {});
+            // Mock the publishMetric function to avoid actual call
+            jest.spyOn(StreamMetricUtils, "publishMetric").mockImplementation(() => {});
       
-      // Act
-      StreamMetricUtils.publishError(metricName, errorType);
+            // Act
+            StreamMetricUtils.publishError(metricName, errorType);
       
-      // Assert
-      expect(logger.info).toHaveBeenCalledWith(
-        "publishErrorMetric - The Error Metric is", 
-        {
-          name: `${CUSTOM_CCP_NAME}${STREAM_METRIC_TYPES.SUCCESS_METRIC}`,
-          data: {
-            count: 0
-          },
-          dimensions: {
-            category: metricName,
-            errorType: errorType,
-            streamsJSVersion: window.connect.version,
-            chatJSVersion: window.connect.ChatJSVersion,
-          }
-        }
-      );
+            // Assert
+            expect(logger.info).toHaveBeenCalledWith(
+                "publishErrorMetric - The Error Metric is", 
+                {
+                    name: `${CUSTOM_CCP_NAME}${STREAM_METRIC_TYPES.SUCCESS_METRIC}`,
+                    data: {
+                        count: 0
+                    },
+                    dimensions: {
+                        category: metricName,
+                        errorType: errorType,
+                        streamsJSVersion: window.connect.version,
+                        chatJSVersion: window.connect.ChatJSVersion,
+                    }
+                }
+            );
+        });
     });
-  });
 });


### PR DESCRIPTION
Info
This change introduces success metric tracking for chat sessions in the Amazon Connect ChatJS library. It adds explicit metric publishing when a chat session is successfully established, this helps to track the  streamsJSVersion and chatJSVersion.

Changes
• Added StreamMetricUtils.publishEvent() call in the _createChatController method to track successful chat session creation and what version streamsJSVersion and chatJSVersion was using.

Testing
• Updated the corresponding unit tests to mock the new publishEvent method
• Ensured backward compatibility with existing implementations
• Verified metric publishing works in both success and error scenarios

Minor Fix:
Simplified the global ChatJS variable definition by removing Object.freeze() and Object.defineProperty(). The change maintains the same functionality of exposing ChatJS metadata globally, but uses direct assignment instead of property definition. Removed related test cases that were checking immutability since that constraint has been lifted.

This change will fix the Cannot redefine property: ChatJS happening in CCP package build due to importing of ChatJS variable multiple time. We are not allowing redefining of ChatJS previously and with this change we are allowing it.