### PR TITLE
Add type definition for getAttachmentURL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.4]
+### Added
+- Add missing typescript declarations for getAttachmentURL() in `index.d.ts` 
+
 ## [3.1.3]
 ### Added
 - Update `index.d.ts` for sendMessage() and sendEvent idempotency key

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-connect-chatjs",
-      "version": "3.1.2",
+      "version": "3.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "detect-browser": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "main": "dist/amazon-connect-chat.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -222,6 +222,7 @@ declare namespace connect {
     sendMessage(args: SendMessageArgs): Promise<ParticipantServiceResponse<SendMessageResult>>;
     sendAttachment(args: SendAttachmentArgs): Promise<ParticipantServiceResponse<SendAttachmentResult>>;
     downloadAttachment(args: DownloadAttachmentArgs): Promise<Blob>;
+    getAttachmentURL(args: GetAttachmentURLArgs): Promise<string>;
     sendEvent(args: SendEventArgs): Promise<ParticipantServiceResponse<SendEventResult>>;
     getTranscript(args: GetTranscriptArgs): Promise<ParticipantServiceResponse<GetTranscriptResult>>;
     connect(args?: ConnectArgs): Promise<ConnectChatResult>;
@@ -335,6 +336,16 @@ declare namespace connect {
     downloadAttachment<T>(
       args: WithMetadata<DownloadAttachmentArgs, T>
     ): Promise<WithMetadata<Blob, T>>;
+
+    /**
+     * Gets the URL for an attachment
+     * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_GetAttachment.html
+     * @param args The arguments of the operation.
+     */
+    getAttachmentURL(args: GetAttachmentURLArgs): Promise<string>;
+    getAttachmentURL<T>(
+      args: WithMetadata<GetAttachmentURLArgs, T>
+    ): Promise<WithMetadata<string, T>>;
 
     /**
      * Sends a message as the current session's participant.
@@ -899,6 +910,14 @@ declare namespace connect {
   }
 
   /**
+   * An object that is transformed to a request of the Amazon Connect Participant Service `GetAttachment` API for URL retrieval.
+   * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_GetAttachment.html
+   */
+  interface GetAttachmentURLArgs {
+    attachmentId: string;
+  }
+
+  /**
    * Represents the response of the Amazon Connect Participant Service `SendEvent` API.
    * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_SendEvent.html#API_SendEvent_ResponseSyntax
    */
@@ -919,6 +938,15 @@ declare namespace connect {
  * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_CompleteAttachmentUpload.html
  */
   interface SendAttachmentResult {
+  }
+
+  /**
+   * Represents the response of the Amazon Connect Participant Service `GetAttachment` API for URL retrieval.
+   * See: https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_GetAttachment.html
+   */
+  interface GetAttachmentURLResult {
+    /** The pre-signed URL for the attachment. */
+    readonly Url: string;
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:*
#290 

*Description of changes:*

Add type definition for getAttachmentURL API.

Testing:
1. Ran typescript compiler check
2. Created a test file and checked the new types in IDE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
