### PR TITLE
Remove websocket incoming message logging from LpcConnectionHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.5]
 ### Changed
-- Remove verbose websocket incoming message logging from LpcConnectionHelper to improve performance and reduce log noise
+- Remove verbose websocket incoming message logging from LpcConnectionHelper
 
 ## [3.1.4]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.5]
+### Changed
+- Remove verbose websocket incoming message logging from LpcConnectionHelper to improve performance and reduce log noise
+
 ## [3.1.4]
 ### Added
 - Add missing typescript declarations for getAttachmentURL() in `index.d.ts` 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-connect-chatjs",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "detect-browser": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "main": "dist/amazon-connect-chat.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/core/connectionHelpers/LpcConnectionHelper.js
+++ b/src/core/connectionHelpers/LpcConnectionHelper.js
@@ -281,7 +281,6 @@ class LpcConnectionHelperBase {
             parsedMessage = JSON.parse(message.content);
             this.eventBus.trigger(ConnectionHelperEvents.IncomingMessage, parsedMessage);
             csmService.addCountMetric(WEBSOCKET_EVENTS.IncomingMessage, CSM_CATEGORY.API);
-            this.logger.info("this.eventBus trigger Websocket incoming message", ConnectionHelperEvents.IncomingMessage, parsedMessage);
         } catch (e) {
             this._sendInternalLogToServer(this.logger.error("Wrong message format"));
         }


### PR DESCRIPTION
- Removed logger.info line that was logging incoming websocket messages
- This reduces log verbosity and improves performance by avoiding logging of potentially sensitive message content

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
