### PR TITLE
Add useDualStack property and dual-stack endpoint support

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -38,14 +38,16 @@ class ChatClientFactoryImpl {
     if (this.clientCache[region]) {
       return this.clientCache[region];
     }
-    let client = this._createAwsClient(region, logMetaData);
+    let client = this._createAwsClient(region, logMetaData, GlobalConfig.getDualStackFlag());
     this.clientCache[region] = client;
     return client;
   }
 
-  _createAwsClient(region, logMetaData) {
+  _createAwsClient(region, logMetaData, useDualStack) {
     let endpointOverride = GlobalConfig.getEndpointOverride();
-    let endpointUrl = `https://participant.connect.${region}.amazonaws.com`;
+    let ipv4EndpointUrl = `https://participant.connect.${region}.amazonaws.com`;
+    let dualStackEndpointUrl = `https://participant.connect.${region}.api.aws`;
+    let endpointUrl = useDualStack ? dualStackEndpointUrl: ipv4EndpointUrl;
     if (endpointOverride) {
       endpointUrl = endpointOverride;
     }

--- a/src/client/client.spec.js
+++ b/src/client/client.spec.js
@@ -13,6 +13,7 @@ jest.mock('../globalConfig', () => {
       getRegion: jest.fn(),
       getEndpointOverride: jest.fn(),
       getCustomUserAgentSuffix: jest.fn(),
+      getDualStackFlag: jest.fn(),
     }
   }
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -223,3 +223,5 @@ export const STREAM_METRIC_TYPES = {
 export const STREAM_METRIC_ERROR_TYPES = {
     INTERNAL_SERVER_ERROR: "InternalServerError",
 };
+
+export const USE_DUAL_STACK_DEFAULT_VALUE = false;

--- a/src/globalConfig.js
+++ b/src/globalConfig.js
@@ -1,4 +1,4 @@
-import { FEATURES, DEFAULT_MESSAGE_RECEIPTS_THROTTLE_MS } from "./constants";
+import { FEATURES, DEFAULT_MESSAGE_RECEIPTS_THROTTLE_MS, USE_DUAL_STACK_DEFAULT_VALUE } from "./constants";
 import { LogManager } from "./log";
 
 class GlobalConfigImpl {
@@ -38,6 +38,7 @@ class GlobalConfigImpl {
         this.messageReceiptThrottleTime = DEFAULT_MESSAGE_RECEIPTS_THROTTLE_MS;
         this.featureChangeListeners = [];
         this.customUserAgentSuffix = "";
+        this.useDualStack = USE_DUAL_STACK_DEFAULT_VALUE;
     }
     update(configInput) {
         var config = configInput || {};
@@ -51,6 +52,7 @@ class GlobalConfigImpl {
         const features = Array.isArray(config.features) ? config.features : this.features.values;
         this.features["values"] = Array.isArray(features) ? [...features] : new Array();
         this.customUserAgentSuffix = config.customUserAgentSuffix || this.customUserAgentSuffix;
+        this.useDualStack = config.useDualStack ?? this.useDualStack;
     }
 
     updateStageRegionCell(config) {
@@ -111,6 +113,10 @@ class GlobalConfigImpl {
         }
         const featureValues = Array.isArray(this.features["values"]) ? this.features["values"] : [];
         this.features["values"] = [...featureValues, feature];
+    }
+
+    getDualStackFlag() {
+        return this.useDualStack;
     }
 
     //private method

--- a/src/globalConfig.spec.js
+++ b/src/globalConfig.spec.js
@@ -29,7 +29,8 @@ const configInput = {
     ...stageRegionCell,
     endpoint: "test-endpoint",
     regionOverride: "test-regionOverride",
-    customUserAgentSuffix: "test-customUserAgentOverride"
+    customUserAgentSuffix: "test-customUserAgentOverride",
+    useDualStack: true
 };
 const logMetaData = {contactId: "abc"};
 const defaultMessageReceiptsError = "WARN [2022-04-12T23:12:36.677Z] ChatJS-GlobalConfig: enabling message-receipts by default; to disable set config.features.messageReceipts.shouldSendMessageReceipts = false ";
@@ -54,6 +55,7 @@ describe("globalConfig", () => {
             expect(GlobalConfig.region).toEqual("us-west-2");
             expect(GlobalConfig.stage).toEqual("prod");
             expect(GlobalConfig.reconnect).toBe(true);
+            expect(GlobalConfig.useDualStack).toBe(false);
         });
         it("should update all and fetch correct config", () => {
             GlobalConfig.update(configInput);
@@ -65,6 +67,11 @@ describe("globalConfig", () => {
             expect(GlobalConfig.getEndpointOverride()).toEqual(configInput.endpoint);
             expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(true);
             expect(GlobalConfig.getCustomUserAgentSuffix()).toEqual(configInput.customUserAgentSuffix);
+            expect(GlobalConfig.getDualStackFlag()).toEqual(configInput.useDualStack);
+
+            // Test disabling useDualStack after enabling it
+            GlobalConfig.update({useDualStack: false});
+            expect(GlobalConfig.getDualStackFlag()).toEqual(false);
         });
         it("should update stage, region and cell and fetch correct config", () => {
             GlobalConfig.updateStageRegionCell(stageRegionCell);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -172,6 +172,12 @@ declare namespace connect {
     readonly webSocketManagerConfig?: {
       isNetworkOnline: () => boolean;
     }
+
+    /**
+     * Whether to use dual-stack endpoints for network connectivity.
+     * @default false
+     */
+    readonly useDualStack?: boolean;
   }
 
   interface ChatLogger {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add useDualStack property in GlobalConfig and IPV6 dual-stack ACPS endpoint support
* Introducing a `useDualStack` configuration flag (defaulted to false) to GlobalConfig
* Implementing dual-stack endpoint URL format (`participant.connect.<region>.api.aws`)
* Modifying ACPS client creation logic to conditionally use IPv4 or dual-stack endpoints based on `useDualStack` configuration
* Added `useDualStack` property in typescript support
* Updated unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
