### PR TITLE
Anhytran/update disconnect participant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0]
+### Changed
+- Enhanced End Chat flow to support disconnect flow experiences
+- Modified `disconnectParticipant()` to defer connection termination until server sends `chatEnded` event
+- Moved cleanup operations from `disconnectParticipant()` to `_handleIncomingMessage()` for server-driven termination
+- Added callback pattern in `_forwardChatEvent()` to ensure proper event ordering during chat termination
+- Enables post-disconnect messaging (surveys, confirmations) while ensuring proper cleanup
+
 ## [3.1.5]
 ### Changed
 - Remove verbose websocket incoming message logging from LpcConnectionHelper

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.1.5",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-connect-chatjs",
-      "version": "3.1.5",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "detect-browser": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "3.1.5",
+  "version": "4.0.0",
   "main": "dist/amazon-connect-chat.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -347,6 +347,9 @@ class ChatController {
                 this._forwardChatEvent(CHAT_EVENTS.CHAT_ENDED, {
                     data: null,
                     chatDetails: this.getChatDetails()
+                }, () => {
+                    this._participantDisconnected = true;
+                    this.cleanUpOnParticipantDisconnect();    
                 });
                 this.breakConnection();
             }
@@ -365,8 +368,8 @@ class ChatController {
         }
     }
 
-    _forwardChatEvent(eventName, eventData) {
-        this.pubsub.triggerAsync(eventName, eventData);
+    _forwardChatEvent(eventName, eventData, callback) {
+        this.pubsub.triggerAsync(eventName, eventData, callback);
     }
 
     _onConnectSuccess(response, connectionDetailsProvider) {
@@ -442,9 +445,6 @@ class ChatController {
             .then(response => {
                 this._sendInternalLogToServer(this.logger.info("Disconnect participant successfully"));
 
-                this._participantDisconnected = true;
-                this.cleanUpOnParticipantDisconnect();
-                this.breakConnection();
                 csmService.addLatencyMetricWithStartTime(ACPS_METHODS.DISCONNECT_PARTICIPANT, startTime, CSM_CATEGORY.API);
                 csmService.addCountAndErrorMetric(ACPS_METHODS.DISCONNECT_PARTICIPANT, CSM_CATEGORY.API, false);
                 response = {...(response || {})};

--- a/src/core/eventbus.js
+++ b/src/core/eventbus.js
@@ -152,8 +152,13 @@ EventBus.prototype.trigger = function(eventName, data) {
  * to this event will be called and are provided with the given arbitrary
  * data object and the name of the event, in that order.
  */
-EventBus.prototype.triggerAsync = function(eventName, data) {
-    setTimeout(() => this.trigger(eventName, data), 0);
+EventBus.prototype.triggerAsync = function(eventName, data, callback) {
+    setTimeout(() => {
+        this.trigger(eventName, data);
+        if (callback) {
+            callback();
+        }
+    }, 0);
 };
 
 /**


### PR DESCRIPTION
Amazon Connect Chat: Enhanced End Chat Flow Implementation

**Problem Statement**
The original "End Chat" button immediately terminated the WebSocket connection after calling disconnectParticipant(), preventing customers from receiving post-disconnect messages like surveys or farewell notifications.

**Solution Overview**
Maintain the WebSocket connection after disconnectParticipant() API call, allowing the chat to remain active until the server sends a chatEnded event.

**Key Technical Changes**
1. Deferred Connection Termination
Removed immediate cleanup from disconnectParticipant() method
Moved connection termination logic to _handleIncomingMessage() when CONTENT_TYPE.chatEnded is received

2. State Management Refactoring
// Before: Immediate cleanup in disconnectParticipant()
this._participantDisconnected = true;
this.hasChatEnded = true;
this.cleanUpOnParticipantDisconnect();
this.breakConnection();

// After: Server-driven cleanup in _handleIncomingMessage()
if (incomingData.ContentType === CONTENT_TYPE.chatEnded) {
    this.hasChatEnded = true;
    this._forwardChatEvent(CHAT_EVENTS.CHAT_ENDED, {
        data: null,
        chatDetails: this.getChatDetails()
    }, () => {
        this._participantDisconnected = true;
        this.cleanUpOnParticipantDisconnect();
    });
    this.breakConnection();
}

3. Event Ordering Fix
Used callback pattern in _forwardChatEvent() to ensure CHAT_ENDED event is published before cleanup
Prevents race conditions between UI notifications and connection termination
