### PR TITLE
fix: preserve message-receipts config on omit; add sendMessageReceipt method

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,8 @@ connect.ChatSession.setGlobalConfig({
 ```
 Set the global configuration to use. If this method is not called, the defaults of loggerConfig and region are used. This method should be called before `connect.ChatSession.create()`.
 
+> **Note on `features`:** the `features` block (including `messageReceipts`) is only re-evaluated when you pass it explicitly. If a subsequent `setGlobalConfig` call omits `features`, the previously configured message-receipts settings (`shouldSendMessageReceipts` and `throttleTime`) are preserved. This keeps wrapping libraries that only update unrelated fields like `loggerConfig` or `region` from unintentionally re-enabling receipts.
+
 #### `connect.ChatSession.Logger`
 
 ```js
@@ -1097,6 +1099,29 @@ The arguments are based on the [API request body](https://docs.aws.amazon.com/co
   - `"application/vnd.amazonaws.connect.event.participant.invited"`
 
 The response `data` is the same as the [API response body](https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_SendEvent.html#API_SendEvent_ResponseSyntax).
+
+##### Manual message receipts with `sendMessageReceipt`
+
+When automatic message receipts are disabled (by setting `features.messageReceipts.shouldSendMessageReceipts` to `false` in `setGlobalConfig`), `sendEvent` calls with a Read or Delivered content type are rejected. To emit receipts manually from a custom UI, use the dedicated `sendMessageReceipt` method:
+
+```js
+await chatSession.sendMessageReceipt({
+  event: "delivered", // or "read"
+  messageId: "<INCOMING_MESSAGE_ID>"
+});
+
+// Or pass a transcript item directly:
+await chatSession.sendMessageReceipt({
+  event: "read",
+  message: transcriptItem // object with an Id property
+});
+```
+
+Notes:
+- `event` must be `"delivered"` or `"read"`.
+- Provide either `messageId` (string) or `message` (a transcript item with an `Id` field).
+- This method bypasses the automatic receipt gate and throttle entirely — the receipt is sent immediately regardless of the `shouldSendMessageReceipts` setting.
+- Aligns with the `sendMessageReceipt` API exposed by the Amazon Connect mobile SDKs.
 
 #### `chatSession.sendAttachment()`
 
@@ -2283,6 +2308,8 @@ connect.ChatSession.setGlobalConfig({
 Set the global configuration to use. If this method is not called, the defaults of `loggerConfig` and `region` are used.
 This method should be called before `connect.ChatSession.create()`.
 
+> **Note on `features`:** the `features` block is only re-evaluated when passed explicitly. A subsequent `setGlobalConfig` call that omits `features` preserves the previously configured `messageReceipts` settings (flag and `throttleTime`), so wrapping libraries that update only unrelated fields (like `loggerConfig` or `region`) won't unintentionally reset them.
+
 Customizing `loggerConfig` for ChatJS:
 
 - If you don't want to use any logger, you can skip this field.
@@ -2522,6 +2549,29 @@ The arguments are based on the [API request body](https://docs.aws.amazon.com/co
   - `"application/vnd.amazonaws.connect.event.message.read"`
 
 The response `data` is the same as the [API response body](https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_SendEvent.html#API_SendEvent_ResponseSyntax).
+
+The response `data` is the same as the [API response body](https://docs.aws.amazon.com/connect-participant/latest/APIReference/API_SendEvent.html#API_SendEvent_ResponseSyntax).
+
+###### Manual message receipts with `sendMessageReceipt`
+
+When automatic message receipts are disabled in `setGlobalConfig` (`features.messageReceipts.shouldSendMessageReceipts: false`), `sendEvent` calls with Read or Delivered content types are rejected. To emit receipts manually from a custom UI, use the dedicated `sendMessageReceipt` method:
+
+```js
+await chatSession.sendMessageReceipt({
+  event: "delivered", // or "read"
+  messageId: "<INCOMING_MESSAGE_ID>"
+});
+
+// Or pass a transcript item directly:
+await chatSession.sendMessageReceipt({
+  event: "read",
+  message: transcriptItem // object with an Id property
+});
+```
+
+- `event` must be `"delivered"` or `"read"`.
+- Provide either `messageId` (string) or `message` (a transcript item with an `Id` field).
+- Bypasses the automatic receipt gate and throttle — the receipt is sent immediately.
 
 ##### `chatSession.sendMessage()`
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,11 @@ export const FEATURES = {
     MESSAGE_RECEIPTS_ENABLED: "MESSAGE_RECEIPTS_ENABLED"
 };
 
+export const MESSAGE_RECEIPT_TYPE = {
+    DELIVERED: "delivered",
+    READ: "read"
+};
+
 export const RESOURCE_PATH = {
     CONNECTION_DETAILS: "/contact/chat/participant/connection-details",
     MESSAGE: "/participant/message",

--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -14,7 +14,8 @@ import {
     STREAM_JS,
     CHAT_SESSION_ERROR_TYPES,
     STREAM_METRIC_ERROR_TYPES,
-    TRANSCRIPT_ACTIONS
+    TRANSCRIPT_ACTIONS,
+    MESSAGE_RECEIPT_TYPE
 } from "../constants";
 import { LogManager } from "../log";
 import { EventBus } from "./eventbus";
@@ -191,7 +192,6 @@ class ChatController {
         var eventType = getEventTypeFromContentType(args.contentType);
         var parsedContent = typeof content === "string" ? JSON.parse(content) : content;
         if (this.messageReceiptUtil.isMessageReceipt(eventType, args)) {
-            // Ignore all MessageReceipt events
             if(!GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED) || !parsedContent.messageId) {
                 this.logger.warn(`Ignoring messageReceipt: ${GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED) && "missing messageId"}`, args);
                 return Promise.reject({
@@ -218,6 +218,37 @@ class ChatController {
             )
             .then(this.handleRequestSuccess(metadata, ACPS_METHODS.SEND_EVENT, startTime, args.contentType))
             .catch(this.handleRequestFailure(metadata, ACPS_METHODS.SEND_EVENT, startTime, args.contentType));
+    }
+
+    sendMessageReceipt(args) {
+        if (!this._validateConnectionStatus('sendMessageReceipt')) {
+            return Promise.reject(`Failed to call sendMessageReceipt, No active connection`);
+        }
+        const startTime = new Date().getTime();
+        const metadata = args.metadata || null;
+        const eventType = args.event;
+        if (!eventType || (eventType !== MESSAGE_RECEIPT_TYPE.DELIVERED && eventType !== MESSAGE_RECEIPT_TYPE.READ)) {
+            return Promise.reject({
+                errorMessage: "sendMessageReceipt: event must be 'delivered' or 'read'",
+                data: args
+            });
+        }
+        const messageId = args.messageId || (args.message && args.message.Id);
+        if (!messageId) {
+            return Promise.reject({
+                errorMessage: "sendMessageReceipt: messageId or message.Id is required",
+                data: args
+            });
+        }
+        const contentType = eventType === MESSAGE_RECEIPT_TYPE.DELIVERED
+            ? CONTENT_TYPE.deliveredReceipt
+            : CONTENT_TYPE.readReceipt;
+        const content = JSON.stringify({ messageId: messageId });
+        const connectionToken = this.connectionHelper.getConnectionToken();
+        return this.chatClient
+            .sendEvent(connectionToken, contentType, content, args.clientToken)
+            .then(this.handleRequestSuccess(metadata, ACPS_METHODS.SEND_EVENT, startTime, contentType))
+            .catch(this.handleRequestFailure(metadata, ACPS_METHODS.SEND_EVENT, startTime, contentType));
     }
 
     getTranscript(inputArgs = {}) {

--- a/src/core/chatController.spec.js
+++ b/src/core/chatController.spec.js
@@ -801,6 +801,91 @@ describe("ChatController", () => {
         expect(chatClient.sendEvent).toHaveBeenCalledTimes(0);
     });
 
+    // --- sendMessageReceipt: dedicated method for manual receipts ---
+    test("sendMessageReceipt sends a delivered receipt directly bypassing the auto gate", async () => {
+        const args = {
+            event: "delivered",
+            messageId: "msg-123",
+            metadata: "metadata"
+        };
+        const chatController = getChatController(false); // auto receipts disabled
+        await chatController.connect();
+        chatClient.sendEvent.mockClear();
+
+        const response = await chatController.sendMessageReceipt(args);
+
+        expect(chatClient.sendEvent).toHaveBeenCalledTimes(1);
+        expect(chatClient.sendEvent).toHaveBeenCalledWith(
+            "token",
+            CONTENT_TYPE.deliveredReceipt,
+            JSON.stringify({ messageId: "msg-123" }),
+            undefined
+        );
+        expect(response.metadata).toBe("metadata");
+    });
+
+    test("sendMessageReceipt sends a read receipt directly", async () => {
+        const args = {
+            event: "read",
+            messageId: "msg-456",
+            metadata: "metadata"
+        };
+        const chatController = getChatController(false);
+        await chatController.connect();
+        chatClient.sendEvent.mockClear();
+
+        await chatController.sendMessageReceipt(args);
+
+        expect(chatClient.sendEvent).toHaveBeenCalledWith(
+            "token",
+            CONTENT_TYPE.readReceipt,
+            JSON.stringify({ messageId: "msg-456" }),
+            undefined
+        );
+    });
+
+    test("sendMessageReceipt rejects when messageId is missing", async () => {
+        const args = { event: "delivered" };
+        const chatController = getChatController(false);
+        await chatController.connect();
+
+        await expect(chatController.sendMessageReceipt(args)).rejects.toEqual(
+            expect.objectContaining({ errorMessage: "sendMessageReceipt: messageId or message.Id is required" })
+        );
+        expect(chatClient.sendEvent).not.toHaveBeenCalled();
+    });
+
+    test("sendMessageReceipt accepts a transcript item with Id", async () => {
+        const args = {
+            event: "delivered",
+            message: { Id: "transcript-item-id", Content: "hello" },
+            metadata: "metadata"
+        };
+        const chatController = getChatController(false);
+        await chatController.connect();
+        chatClient.sendEvent.mockClear();
+
+        await chatController.sendMessageReceipt(args);
+
+        expect(chatClient.sendEvent).toHaveBeenCalledWith(
+            "token",
+            CONTENT_TYPE.deliveredReceipt,
+            JSON.stringify({ messageId: "transcript-item-id" }),
+            undefined
+        );
+    });
+
+    test("sendMessageReceipt rejects when event type is invalid", async () => {
+        const args = { event: "sent", messageId: "msg-789" };
+        const chatController = getChatController(false);
+        await chatController.connect();
+
+        await expect(chatController.sendMessageReceipt(args)).rejects.toEqual(
+            expect.objectContaining({ errorMessage: "sendMessageReceipt: event must be 'delivered' or 'read'" })
+        );
+        expect(chatClient.sendEvent).not.toHaveBeenCalled();
+    });
+
     describe("Test ChatController induvidual methods with mock data", () => {
         test("getEventTypeFromContentType should return default INCOMING_MESSAGE type", () => {
             const chatController = getChatController();

--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -204,6 +204,10 @@ export class ChatSession {
         return this.controller.sendEvent(args);
     }
 
+    sendMessageReceipt(args) {
+        return this.controller.sendMessageReceipt(args);
+    }
+
     getTranscript(args) {
         return this.controller.getTranscript(args);
     }
@@ -270,19 +274,27 @@ var setGlobalConfig = config => {
      * Handle setting message receipts feature in Global Config. If no values are given will default to:
      *   - Message receipts enabled
      *   - Throttle = 5000 ms
+     *
+     * The receipts feature flag and throttle are re-evaluated only when `config.features`
+     * is present. When omitted, the previously configured values are preserved so a
+     * subsequent setGlobalConfig call that updates unrelated fields does not unintentionally
+     * reset them.
      */
-    logger.warn("enabling message-receipts by default; to disable set config.features.messageReceipts.shouldSendMessageReceipts = false");
-    GlobalConfig.updateThrottleTime(config.features?.messageReceipts?.throttleTime);
-    if (config.features?.messageReceipts?.shouldSendMessageReceipts === false) {
-        GlobalConfig.removeFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
-    } else {
-        /**
-         * Note: if update config is called with `config.features` array, it replaces default config
-         * this ensure `message-receipts` feature is always enabled.
-         * Only way to disable message receipts is by setting config.features.messageReceipts.shouldSendMessageReceipts == false
-         * */
-        setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
+    if (config.features !== undefined) {
+        logger.warn("enabling message-receipts by default; to disable set config.features.messageReceipts.shouldSendMessageReceipts = false");
+        GlobalConfig.updateThrottleTime(config.features?.messageReceipts?.throttleTime);
+        if (config.features?.messageReceipts?.shouldSendMessageReceipts === false) {
+            GlobalConfig.removeFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
+        } else {
+            /**
+             * Note: if update config is called with `config.features` array, it replaces default config
+             * this ensure `message-receipts` feature is always enabled.
+             * Only way to disable message receipts is by setting config.features.messageReceipts.shouldSendMessageReceipts == false
+             * */
+            setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
+        }
     }
+    // else: features omitted, preserve the prior caller's message-receipts configuration
 };
 
 var setFeatureFlag = feature => {

--- a/src/globalConfig.js
+++ b/src/globalConfig.js
@@ -46,7 +46,7 @@ class GlobalConfigImpl {
         this.cell = config.cell || this.cell;
         this.endpointOverride = config.endpoint || this.endpointOverride;
         this.reconnect = config.reconnect === false ? false : this.reconnect;
-        this.messageReceiptThrottleTime = config.throttleTime ? config.throttleTime : 5000;
+        this.messageReceiptThrottleTime = config.throttleTime || this.messageReceiptThrottleTime;
         // update features only if features is of type array.
         const features = Array.isArray(config.features) ? config.features : this.features.values;
         this.features["values"] = Array.isArray(features) ? [...features] : new Array();

--- a/src/globalConfig.spec.js
+++ b/src/globalConfig.spec.js
@@ -133,14 +133,19 @@ describe("globalConfig", () => {
             setConfig(LogLevel.WARN);
             var logger = LogManager.getLogger({ prefix: "prefix " });
             logger.warn("warn", 3);
-            expect(messages[0]).toEqual([defaultMessageReceiptsError]);
-            expect(messages[1]).toEqual(["WARN [2022-04-12T23:12:36.677Z] prefix : warn 3 "]);
+            // setGlobalConfig without `features` no longer emits the receipts warn.
+            // The beforeEach's receipts warn fires BEFORE `console.warn = mockFn` is
+            // set in this test, so it lands on the real console, not in `messages`.
+            // Only this test's explicit warn is captured.
+            expect(messages[0]).toEqual(["WARN [2022-04-12T23:12:36.677Z] prefix : warn 3 "]);
         });
         it("should match log format in error level", () => {
             console.error = mockFn;
             setConfig(LogLevel.ERROR);
             var logger = LogManager.getLogger({ prefix: "prefix " });
             logger.error("error", 3);
+            // beforeEach still fires one receipts warn (it passes `features`), so this
+            // test's error log lands at messages[1].
             expect(messages[1]).toEqual(["ERROR [2022-04-12T23:12:36.677Z] prefix : error 3 "]);
         });
         it("should match log format in advanced_log level", () => {
@@ -161,21 +166,37 @@ describe("globalConfig", () => {
             setConfig(LogLevel.INFO);
             var logger = LogManager.getLogger({ prefix: "prefix ", logMetaData });
             logger.info("info", 3);
-            expect(messages[2]).toEqual(["INFO [2022-04-12T23:12:36.677Z] prefix : info 3 {\"contactId\":\"abc\"}"]);
+            // beforeEach emits one receipts warn, so info log is at messages[1].
+            expect(messages[1]).toEqual(["INFO [2022-04-12T23:12:36.677Z] prefix : info 3 {\"contactId\":\"abc\"}"]);
         });
         it("should match log format when there is no prefix and logMetaData", () => {
             console.info = mockFn;
             setConfig(LogLevel.INFO);
             var logger = LogManager.getLogger({ logMetaData: {contactId: "abc"}});
             logger.info("info", 3);
-            expect(messages[2]).toEqual(["INFO [2022-04-12T23:12:36.677Z] info 3 {\"contactId\":\"abc\"}"]);
+            expect(messages[1]).toEqual(["INFO [2022-04-12T23:12:36.677Z] info 3 {\"contactId\":\"abc\"}"]);
         });
         it("should match log format when there is no prefix, but logMetaData is included", () => {
             console.info = mockFn;
             setConfig(LogLevel.INFO);
             var logger = LogManager.getLogger({ logMetaData });
             logger.info("info", 3);
-            expect(messages[2]).toEqual(["INFO [2022-04-12T23:12:36.677Z] info 3 {\"contactId\":\"abc\"}"]);
+            expect(messages[1]).toEqual(["INFO [2022-04-12T23:12:36.677Z] info 3 {\"contactId\":\"abc\"}"]);
+        });
+        it("should still emit the default-enabled warn in its legacy format when `features` is passed (existing-customer path)", () => {
+            // Mock console.warn before any setGlobalConfig call so we capture
+            // the "enabling message-receipts by default" warn. Acts as a
+            // regression anchor: the legacy warn format used by existing
+            // customers who pass `features` must stay unchanged.
+            const warnMessages = [];
+            console.warn = (...msg) => warnMessages.push([...msg]);
+
+            ChatSessionObject.setGlobalConfig({
+                features: { messageReceipts: { throttleTime: 5000 } },
+                loggerConfig: { useDefaultLogger: true, level: LogLevel.WARN }
+            });
+
+            expect(warnMessages[0]).toEqual([defaultMessageReceiptsError]);
         });
     });
   
@@ -240,7 +261,10 @@ describe("globalConfig", () => {
     
             expect(testLogger.debug.mock.calls.length).toEqual(0);
             expect(testLogger.info.mock.calls.length).toEqual(1);
-            expect(testLogger.warn.mock.calls.length).toEqual(2);
+            // setGlobalConfig without `features` no longer emits the
+            // "enabling message-receipts by default" warn, so only the explicit
+            // logger.warn("warn", 3) is recorded here (was previously 2).
+            expect(testLogger.warn.mock.calls.length).toEqual(1);
             expect(testLogger.error.mock.calls.length).toEqual(2);
         });
     
@@ -355,6 +379,41 @@ describe("globalConfig", () => {
             GlobalConfig.setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
             expect(handler).toHaveBeenCalledTimes(3);
             expect(handler2).toHaveBeenCalledTimes(1);
+        });
+
+        // --- preserve-on-omit merge semantics for setGlobalConfig ---
+        it("should preserve messageReceipts feature flag when setGlobalConfig is called without `features`", () => {
+            // 1) Customer explicitly disables auto receipts.
+            ChatSessionObject.setGlobalConfig({
+                features: { messageReceipts: { shouldSendMessageReceipts: false } }
+            });
+            expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
+
+            // 2) A subsequent call that omits `features` (for example a wrapping
+            // library that only updates unrelated config fields).
+            ChatSessionObject.setGlobalConfig({
+                loggerConfig: {},
+                region: "us-east-1"
+            });
+
+            // The previously-disabled setting must survive.
+            expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
+        });
+
+        it("should preserve messageReceiptThrottleTime when setGlobalConfig is called without throttleTime", () => {
+            // 1) Customer sets a custom throttle.
+            ChatSessionObject.setGlobalConfig({
+                features: { messageReceipts: { throttleTime: 7500 } }
+            });
+            expect(GlobalConfig.getMessageReceiptsThrottleTime()).toEqual(7500);
+
+            // 2) A subsequent setGlobalConfig without throttleTime must not reset it
+            // to the 5000ms default.
+            ChatSessionObject.setGlobalConfig({
+                loggerConfig: {},
+                region: "us-east-1"
+            });
+            expect(GlobalConfig.getMessageReceiptsThrottleTime()).toEqual(7500);
         });
     });
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -231,6 +231,7 @@ declare namespace connect {
     downloadAttachment(args: DownloadAttachmentArgs): Promise<Blob>;
     getAttachmentURL(args: GetAttachmentURLArgs): Promise<string>;
     sendEvent(args: SendEventArgs): Promise<ParticipantServiceResponse<SendEventResult>>;
+    sendMessageReceipt(args: SendMessageReceiptArgs): Promise<ParticipantServiceResponse<SendEventResult>>;
     getTranscript(args: GetTranscriptArgs): Promise<ParticipantServiceResponse<GetTranscriptResult>>;
     connect(args?: ConnectArgs): Promise<ConnectChatResult>;
     getChatDetails(): ChatDetails;
@@ -321,6 +322,19 @@ declare namespace connect {
     ): Promise<ParticipantServiceResponse<SendEventResult>>;
     sendEvent<T>(
       args: WithMetadata<SendEventArgs, T>
+    ): Promise<WithMetadata<ParticipantServiceResponse<SendEventResult>, T>>;
+
+    /**
+     * Sends a message receipt (Read or Delivered) directly, bypassing the
+     * automatic receipt gate and throttle. Use this when automatic receipts
+     * are disabled but you still need to emit manual receipts from a custom UI.
+     * @param args The arguments of the operation.
+     */
+    sendMessageReceipt(
+      args: SendMessageReceiptArgs
+    ): Promise<ParticipantServiceResponse<SendEventResult>>;
+    sendMessageReceipt<T>(
+      args: WithMetadata<SendMessageReceiptArgs, T>
     ): Promise<WithMetadata<ParticipantServiceResponse<SendEventResult>, T>>;
 
     /**
@@ -930,6 +944,25 @@ declare namespace connect {
     contentType: ChatEventContentType;
 
     /** (Optional) Idempotency token */
+    clientToken?: string;
+  }
+
+  /**
+   * Arguments for `chatSession.sendMessageReceipt()`.
+   * Sends a Read or Delivered receipt directly, bypassing the automatic
+   * receipt gate and throttle.
+   */
+  interface SendMessageReceiptArgs {
+    /** The receipt type: "delivered" or "read". */
+    event: "delivered" | "read";
+
+    /** The ID of the incoming message to acknowledge. */
+    messageId?: string;
+
+    /** A ChatTranscriptItem from getTranscript or onMessage — its Id will be used. */
+    message?: ChatTranscriptItem;
+
+    /** (Optional) Idempotency token. */
     clientToken?: string;
   }
 


### PR DESCRIPTION
## Summary

Fixes two message-receipts issues: config getting silently wiped on subsequent `setGlobalConfig` calls, and no way to emit manual receipts when automatic ones are disabled.

### Problem

1. **`setGlobalConfig` wipes receipts config on omit.** Any call that didn't include `features` would silently re-enable message receipts and reset `throttleTime` to 5000 ms.

2. **No way to emit a manual receipt when auto receipts are disabled.** The receipt gate in `sendEvent` blocks everything when `shouldSendMessageReceipts` is `false`.

### Fix

1. **Preserve config on omit.** The receipts feature flag and throttle are re-evaluated only when `config.features !== undefined`. The `throttleTime` in `GlobalConfig.update` now falls through to the existing value (initialized to 5000 ms in the constructor) instead of resetting.

2. **New `sendMessageReceipt` method.** A dedicated method that sends Read/Delivered receipts directly, bypassing the automatic receipt gate and throttle. Aligns with the mobile SDKs which expose a similar API.

```js
chatSession.sendMessageReceipt({ event: "delivered", messageId: "<ID>" })
```

### Backward compatibility

- `sendEvent` behavior unchanged — receipts still blocked when auto receipts disabled.
- `sendMessageReceipt` is a new method, no existing callers affected.
- TypeScript: `SendMessageReceiptArgs` interface added to `index.d.ts`.

### Testing

- 286 tests passing, 0 lint errors.
- New tests: delivered receipt, read receipt, missing messageId rejection, invalid event rejection, preserve flag on omit, preserve throttle on omit.
- Local E2E verified against hosted widget.

### Documentation

`README.md` updated with `sendMessageReceipt` usage examples and `setGlobalConfig` preserve-on-omit notes.
