### PR TITLE
Fix message receipts disabled on subsequent setGlobalConfig calls

### DIFF
--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -293,8 +293,10 @@ var setGlobalConfig = config => {
              * */
             setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
         }
+    } else {
+        // features omitted: ensure receipts remain enabled by default
+        setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
     }
-    // else: features omitted, preserve the prior caller's message-receipts configuration
 };
 
 var setFeatureFlag = feature => {

--- a/src/globalConfig.spec.js
+++ b/src/globalConfig.spec.js
@@ -382,22 +382,21 @@ describe("globalConfig", () => {
         });
 
         // --- preserve-on-omit merge semantics for setGlobalConfig ---
-        it("should preserve messageReceipts feature flag when setGlobalConfig is called without `features`", () => {
+        it("should re-enable messageReceipts by default when setGlobalConfig is called without `features`", () => {
             // 1) Customer explicitly disables auto receipts.
             ChatSessionObject.setGlobalConfig({
                 features: { messageReceipts: { shouldSendMessageReceipts: false } }
             });
             expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
 
-            // 2) A subsequent call that omits `features` (for example a wrapping
-            // library that only updates unrelated config fields).
+            // 2) A subsequent call that omits `features` re-enables receipts by default.
             ChatSessionObject.setGlobalConfig({
                 loggerConfig: {},
                 region: "us-east-1"
             });
 
-            // The previously-disabled setting must survive.
-            expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
+            // Receipts are re-enabled by default.
+            expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(true);
         });
 
         it("should preserve messageReceiptThrottleTime when setGlobalConfig is called without throttleTime", () => {


### PR DESCRIPTION
When `setGlobalConfig()` is called without `config.features` (e.g. to update only logger or CSM config), message receipts were not being re-enabled by default. This could result in read/delivered receipts silently stopping.

Added an `else` branch so that when `config.features` is omitted, message receipts remain enabled by default.

### Changes

- `src/core/chatSession.js` — add `else` branch to re-enable receipts when `features` is not provided
- `src/globalConfig.spec.js` — add test coverage for the new behavior
