### PR TITLE
fix: preserve messageReceipts config across setGlobalConfig calls; ad…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `setGlobalConfig` now preserves message-receipts configuration when the caller omits the `features` field. Previously, any subsequent call (e.g., from AmazonConnectStreams updating only `loggerConfig` and `region`) would re-enable receipts even if they were explicitly disabled. Receipts are still enabled by default on first call if no prior explicit configuration exists.
+- `setGlobalConfig` no longer marks message-receipts as explicitly configured when `features` is passed but does not include a `messageReceipts` key (or sets it to `null`). This ensures a customer's prior explicit configuration is preserved across calls that supply other feature flags.
+- Added `SendMessageReceiptArgs` interface and `sendMessageReceipt()` typings to `src/index.d.ts` for TypeScript consumers.
 
 ## [5.0.0]
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-connect-chatjs",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "main": "dist/amazon-connect-chat.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -281,18 +281,21 @@ var setGlobalConfig = config => {
      * reset them.
      */
     //Message Receipts enabled by default
-    if (!config.features) {
+    const messageReceiptsConfig = config.features?.messageReceipts;
+    if (messageReceiptsConfig === undefined || messageReceiptsConfig === null) {
+        // Caller did not configure messageReceipts on this call (undefined or null).
+        // Default-enable only if the customer has never explicitly configured them in a prior call.
         if (!GlobalConfig.isMessageReceiptsExplicitlyConfigured()) {
             setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
         }
-    } else if (!(config.features?.messageReceipts?.shouldSendMessageReceipts === false)) {
+    } else if (messageReceiptsConfig.shouldSendMessageReceipts !== false) {
         logger.warn("enabling message-receipts by default; to disable set config.features.messageReceipts.shouldSendMessageReceipts = false");
         setFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
-        GlobalConfig.updateThrottleTime(config.features?.messageReceipts?.throttleTime);
+        GlobalConfig.updateThrottleTime(messageReceiptsConfig.throttleTime);
         GlobalConfig.setMessageReceiptsExplicitlyConfigured();
     } else {
         GlobalConfig.removeFeatureFlag(FEATURES.MESSAGE_RECEIPTS_ENABLED);
-        GlobalConfig.updateThrottleTime(config.features?.messageReceipts?.throttleTime);
+        GlobalConfig.updateThrottleTime(messageReceiptsConfig.throttleTime);
         GlobalConfig.setMessageReceiptsExplicitlyConfigured();
     }
 };

--- a/src/globalConfig.spec.js
+++ b/src/globalConfig.spec.js
@@ -498,4 +498,44 @@ describe("message-receipts config behavior", () => {
         });
         expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(true);
     });
+
+    it("should preserve disabled state when a later setGlobalConfig passes features but omits messageReceipts", () => {
+        // Customer explicitly disables receipts
+        ChatSessionObject.setGlobalConfig({
+            features: { messageReceipts: { shouldSendMessageReceipts: false } }
+        });
+        expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
+
+        // A later caller (e.g., Streams) passes features but does not configure messageReceipts
+        ChatSessionObject.setGlobalConfig({
+            features: []
+        });
+        expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
+
+        ChatSessionObject.setGlobalConfig({
+            features: { someOtherFeature: true }
+        });
+        expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
+    });
+
+    it("should not mark messageReceipts explicit when features is passed but messageReceipts is omitted", () => {
+        ChatSessionObject.setGlobalConfig({
+            features: []
+        });
+        expect(GlobalConfig.isMessageReceiptsExplicitlyConfigured()).toEqual(false);
+        expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(true);
+    });
+
+    it("should treat features.messageReceipts === null the same as undefined and not throw", () => {
+        // First disable receipts explicitly so we can assert the null call preserves it
+        ChatSessionObject.setGlobalConfig({
+            features: { messageReceipts: { shouldSendMessageReceipts: false } }
+        });
+        expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
+
+        expect(() => ChatSessionObject.setGlobalConfig({
+            features: { messageReceipts: null }
+        })).not.toThrow();
+        expect(GlobalConfig.isFeatureEnabled(FEATURES.MESSAGE_RECEIPTS_ENABLED)).toEqual(false);
+    });
 });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -953,16 +953,16 @@ declare namespace connect {
    * receipt gate and throttle.
    */
   interface SendMessageReceiptArgs {
-    /** The receipt type: "delivered" or "read". */
+    /** The receipt event type. */
     event: "delivered" | "read";
 
-    /** The ID of the incoming message to acknowledge. */
+    /** The ID of the message to acknowledge. Takes precedence over `message.Id`. */
     messageId?: string;
 
-    /** A ChatTranscriptItem from getTranscript or onMessage — its Id will be used. */
-    message?: ChatTranscriptItem;
+    /** A transcript item or any object exposing `Id`. Used when `messageId` is not supplied. */
+    message?: { Id: string };
 
-    /** (Optional) Idempotency token. */
+    /** Optional client token forwarded to the underlying SendEvent call. */
     clientToken?: string;
   }
 


### PR DESCRIPTION
## Description
- Fix: `setGlobalConfig` now preserves message-receipts config when caller omits `features` field
- Fix: `setGlobalConfig` no longer marks receipts as explicitly configured when `features.messageReceipts` is null/omitted
- Add: `sendMessageReceipt()` method for manual receipt sending, bypassing gate/throttle
- Add: TypeScript typings for `SendMessageReceiptArgs` and `sendMessageReceipt()`

## Testing
- Unit tests added in `src/globalConfig.spec.js`
- Existing tests pass
- Local testing in gamma

## Related
- Internal CR: [CR-277661149](https://code.amazon.com/reviews/CR-277661149/revisions/1#/diff)
- Version bump: 5.1.0 → 5.1.1