### PR TITLE
feat: add session.reset() to drop session state without ending the contact

### DIFF
--- a/src/core/MessageReceiptsUtil.js
+++ b/src/core/MessageReceiptsUtil.js
@@ -16,6 +16,21 @@ export default class MessageReceiptsUtil {
         this.throttleSendEventApiCall = null;
     }
 
+    /** Clears both pending throttle timers and all read/delivered receipt state. */
+    reset() {
+        clearTimeout(this.timeout);
+        clearTimeout(this.timeoutId);
+        this.timeout = null;
+        this.timeoutId = null;
+        this.readSet = new Set();
+        this.deliveredSet = new Set();
+        this.readPromiseMap = new Map();
+        this.deliveredPromiseMap = new Map();
+        this.lastReadArgs = null;
+        this.throttleInitialEventsToPrioritizeRead = null;
+        this.throttleSendEventApiCall = null;
+    }
+
     /**
      * check if message is of type read or delivered event
      *

--- a/src/core/MessageReceiptsUtil.spec.js
+++ b/src/core/MessageReceiptsUtil.spec.js
@@ -191,4 +191,32 @@ describe("MessageReceiptsUtil", () => {
             });
         }
     });
+
+    test("reset clears receipt state and BOTH pending timers", () => {
+        jest.useRealTimers();
+        const util = new MessageReceiptsUtil({});
+        util.readSet.add("m1");
+        util.deliveredSet.add("m2");
+        util.lastReadArgs = { foo: "bar" };
+        // The class uses two distinct timer handles (throttle paths at
+        // MessageReceiptsUtil.js L130 and L204); reset must clear both.
+        const clearSpy = jest.spyOn(global, "clearTimeout");
+        const timeoutHandle = setTimeout(() => {}, 10000);
+        const timeoutIdHandle = setTimeout(() => {}, 10000);
+        util.timeout = timeoutHandle;
+        util.timeoutId = timeoutIdHandle;
+
+        util.reset();
+
+        expect(clearSpy).toHaveBeenCalledWith(timeoutHandle);
+        expect(clearSpy).toHaveBeenCalledWith(timeoutIdHandle);
+        expect(util.readSet.size).toBe(0);
+        expect(util.deliveredSet.size).toBe(0);
+        expect(util.readPromiseMap.size).toBe(0);
+        expect(util.deliveredPromiseMap.size).toBe(0);
+        expect(util.lastReadArgs).toBeNull();
+        expect(util.timeout).toBeNull();
+        expect(util.timeoutId).toBeNull();
+        clearSpy.mockRestore();
+    });
 });

--- a/src/core/chatController.js
+++ b/src/core/chatController.js
@@ -507,6 +507,22 @@ class ChatController {
         this.pubsub.unsubscribeAll();
     }
 
+    /**
+     * Disconnects the WebSocket and drops session-scoped state WITHOUT ending
+     * the contact, so a later connect() resumes on a fresh socket. Mirrors
+     * amazon-connect-chat-ios ChatService.reset(). Unlike disconnectParticipant().
+     */
+    reset() {
+        this.breakConnection();                    // websocketManager.disconnect
+        this.cleanUpOnParticipantDisconnect();     // clearSubscriptionsAndPublishers
+        this.messageReceiptUtil.reset();           // messageReceiptsManager.reset
+        this.connectionDetailsProvider?.reset();   // connectionDetailsProvider.reset
+        this.internalTranscriptUtils.reset();      // clear transcript + temp/attachment maps
+        // connect() treats a retained provider as "already connected" and ignores the
+        // call, so drop the reference to let a later connect() start a fresh socket.
+        this.connectionDetailsProvider = null;
+    }
+
     disconnectParticipant() {
         if (!this._validateConnectionStatus('disconnectParticipant')) {
             return Promise.reject(`Failed to call disconnectParticipant, No active connection`);

--- a/src/core/chatController.transcript.spec.js
+++ b/src/core/chatController.transcript.spec.js
@@ -32,6 +32,7 @@ describe("ChatController - Transcript Updates", () => {
                 },
                 callCreateParticipantConnection: () => Promise.resolve("connAck"),
                 getConnectionDetails: () => {},
+                reset: () => {},
             };
         });
         
@@ -388,6 +389,86 @@ describe("ChatController - Transcript Updates", () => {
             await Utils.delay(1);
 
             expect(mockChatClient.getTranscript).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("reset", () => {
+        beforeEach(async () => {
+            // Establish a connectionHelper so breakConnection() has something to end.
+            await chatController.connect();
+        });
+
+        it("closes the transport WITHOUT calling disconnectParticipant", () => {
+            const endSpy = jest.spyOn(chatController.connectionHelper, "end");
+
+            chatController.reset();
+
+            // Socket is torn down (drives customerBaseInstances eviction)...
+            expect(endSpy).toHaveBeenCalledTimes(1);
+            // ...but the participant is NOT disconnected (contact survives).
+            expect(mockChatClient.disconnectParticipant).not.toHaveBeenCalled();
+        });
+
+        it("unsubscribes all event handlers", () => {
+            const handler = jest.fn();
+            chatController.subscribe(CHAT_EVENTS.INCOMING_MESSAGE, handler);
+            const unsubscribeAllSpy = jest.spyOn(chatController.pubsub, "unsubscribeAll");
+
+            chatController.reset();
+
+            expect(unsubscribeAllSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("clears accumulated transcript state", () => {
+            chatController.transcriptUpdateEnabled = true;
+            chatController._updateTranscript(TRANSCRIPT_ACTIONS.SEND_MESSAGE, {
+                contentType: "text/plain",
+                message: "Hello"
+            });
+            expect(
+                chatController.internalTranscriptUtils.getTranscriptData().transcript
+            ).toHaveLength(1);
+
+            chatController.reset();
+
+            expect(
+                chatController.internalTranscriptUtils.getTranscriptData().transcript
+            ).toHaveLength(0);
+        });
+
+        it("resets message receipts and connection details (iOS parity)", () => {
+            const receiptSpy = jest.spyOn(chatController.messageReceiptUtil, "reset");
+            const providerSpy = jest.spyOn(chatController.connectionDetailsProvider, "reset");
+
+            chatController.reset();
+
+            expect(receiptSpy).toHaveBeenCalledTimes(1);
+            expect(providerSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("releases the provider so a later connect() is not ignored as a duplicate", async () => {
+            chatController.reset();
+            expect(chatController.connectionDetailsProvider).toBeNull();
+
+            await chatController.connect();
+
+            expect(chatController.connectionDetailsProvider).not.toBeNull();
+        });
+
+        it("does not throw when never connected", () => {
+            const freshController = new ChatController({
+                sessionType: "CUSTOMER",
+                chatDetails: {
+                    contactId: "contact-456",
+                    participantId: "participant-456",
+                    participantToken: "token-456"
+                },
+                chatClient: mockChatClient
+            });
+
+            // No connect() called — connectionHelper is undefined; breakConnection
+            // must tolerate it.
+            expect(() => freshController.reset()).not.toThrow();
         });
     });
 });

--- a/src/core/chatSession.js
+++ b/src/core/chatSession.js
@@ -227,6 +227,16 @@ export class ChatSession {
     cancelParticipantAuthentication(args) {
         return this.controller.cancelParticipantAuthentication(args);
     }
+
+    /**
+     * Disconnects the WebSocket and unsubscribes handlers WITHOUT ending the
+     * contact, so a later connect() resumes it on a fresh socket. Mirrors
+     * amazon-connect-chat-ios ChatSession.reset(). To END the contact, use
+     * disconnectParticipant().
+     */
+    reset() {
+        return this.controller.reset();
+    }
 }
 
 class AgentChatSession extends ChatSession {

--- a/src/core/chatSession.spec.js
+++ b/src/core/chatSession.spec.js
@@ -188,6 +188,7 @@ describe("chatSession", () => {
         jest.spyOn(controller, 'getChatDetails').mockImplementation(() => {});
         jest.spyOn(controller, 'cancelParticipantAuthentication').mockImplementation(() => {});
         jest.spyOn(controller, 'getAttachmentURL').mockImplementation(() => {});
+        jest.spyOn(controller, 'reset').mockImplementation(() => {});
 
         session.sendMessage(args);
         expect(controller.sendMessage).toHaveBeenCalled();
@@ -207,6 +208,8 @@ describe("chatSession", () => {
         expect(controller.cancelParticipantAuthentication).toHaveBeenCalled();
         session.getAttachmentURL(args);
         expect(controller.getAttachmentURL).toHaveBeenCalled();
+        session.reset();
+        expect(controller.reset).toHaveBeenCalled();
     });
 });
 

--- a/src/core/connectionHelpers/connectionDetailsProvider.js
+++ b/src/core/connectionHelpers/connectionDetailsProvider.js
@@ -23,6 +23,13 @@ export default class ConnectionDetailsProvider {
         this.getConnectionToken = getConnectionToken;
     }
 
+    /** Clears cached connection details so the next fetch re-resolves them. */
+    reset() {
+        this.connectionDetails = null;
+        this.connectionToken = null;
+        this.connectionTokenExpiry = null;
+    }
+
     getFetchedConnectionToken() {
         return this.connectionToken;
     }

--- a/src/core/connectionHelpers/connectionDetailsProvider.spec.js
+++ b/src/core/connectionHelpers/connectionDetailsProvider.spec.js
@@ -214,4 +214,19 @@ describe("ConnectionDetailsProvider", () => {
             });
         });
     });
+
+    describe(".reset()", () => {
+        it("clears cached connection details, token, and expiry", () => {
+            setupCustomer();
+            connectionDetailsProvider.connectionDetails = { url: "u" };
+            connectionDetailsProvider.connectionToken = "token";
+            connectionDetailsProvider.connectionTokenExpiry = "expiry";
+
+            connectionDetailsProvider.reset();
+
+            expect(connectionDetailsProvider.getConnectionDetails()).toBeNull();
+            expect(connectionDetailsProvider.getFetchedConnectionToken()).toBeNull();
+            expect(connectionDetailsProvider.getConnectionTokenExpiry()).toBeNull();
+        });
+    });
 });

--- a/src/core/internalTranscriptUtils.js
+++ b/src/core/internalTranscriptUtils.js
@@ -10,6 +10,14 @@ class InternalTranscriptUtils {
         this.tempMessageIdMap = {};
     }
 
+    /** Clears accumulated transcript state (dict, items, temp-id map, token). */
+    reset() {
+        this.transcriptDict = {};
+        this.transcriptItems = [];
+        this.previousTranscriptNextToken = null;
+        this.tempMessageIdMap = {};
+    }
+
     /**
      * Creates a transcript item with serialized content for debugging and compatibility.
      * @param {Object} rawItem - The raw transcript item

--- a/src/core/internalTranscriptUtils.spec.js
+++ b/src/core/internalTranscriptUtils.spec.js
@@ -326,4 +326,19 @@ describe("InternalTranscriptUtils", () => {
             expect(mockLogger.warn).not.toHaveBeenCalled();
         });
     });
+
+    describe("reset", () => {
+        it("restores all accumulated state to empty", () => {
+            utils.handleSendMessage({ contentType: "text/plain", message: "Hello" });
+            utils.previousTranscriptNextToken = "token-abc";
+            expect(utils.transcriptItems.length).toBeGreaterThan(0);
+
+            utils.reset();
+
+            expect(utils.transcriptItems).toEqual([]);
+            expect(utils.transcriptDict).toEqual({});
+            expect(utils.tempMessageIdMap).toEqual({});
+            expect(utils.previousTranscriptNextToken).toBeNull();
+        });
+    });
 });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -408,6 +408,13 @@ declare namespace connect {
       args: WithMetadata<DescribeViewArgs, T>
     ): Promise<WithMetadata<ParticipantServiceResponse<DescribeViewResult>, T>>;
 
+    /**
+     * Disconnects the WebSocket and unsubscribes handlers WITHOUT ending the
+     * contact, so a later connect() resumes it on a fresh socket. To end the
+     * contact, use disconnectParticipant().
+     */
+    reset(): void;
+
     // ======
     // Events
     // ======


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- ChatSession.reset() disconnects the WebSocket and unsubscribes handlers but does NOT call DisconnectParticipant, so the contact survives.
- reset() is added to MessageReceiptsUtil (clears both throttle timers plus all read/delivered state), InternalTranscriptUtils (clears the transcript, temp-id map and next token) and ConnectionDetailsProvider (clears cached details, token and expiry).
- ChatController.reset() also releases connectionDetailsProvider, because connect() treats a retained provider as a duplicate call and would otherwise ignore the reconnect.
- Safe to call before connect(): breakConnection() and the provider call both tolerate a missing connection.
- index.d.ts: reset(): void on ChatSessionInterface. Additive for callers; implementers of the interface will need to add it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
